### PR TITLE
feat: make job executor max_workers configurable via TA_MAX_WORKERS e…

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -76,7 +76,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-_executor = ThreadPoolExecutor(max_workers=2)
+_executor = ThreadPoolExecutor(max_workers=int(os.getenv("TA_MAX_WORKERS", "2")))
 _jobs_lock = Lock()
 _jobs: Dict[str, Dict[str, Any]] = {}
 


### PR DESCRIPTION
…nv var

Default remains 2 to preserve existing behavior. Set TA_MAX_WORKERS=N to allow more concurrent analysis jobs when LLM API quota permits.