### PR TITLE
feat: watchlist & scheduled daily analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
 # 启动命令
-CMD ["uv", "run", "python", "-m", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uv", "run", "tradingagents-api"]

--- a/api/database.py
+++ b/api/database.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime, timezone
 from typing import Generator
 
-from sqlalchemy import Boolean, create_engine, Column, String, DateTime, Text, Integer, Float, JSON, text
+from sqlalchemy import Boolean, create_engine, Column, String, DateTime, Text, Integer, Float, JSON, UniqueConstraint, event, text
 from sqlalchemy.orm import declarative_base, sessionmaker, Session
 
 # Database URL - default to SQLite for simplicity
@@ -17,6 +17,12 @@ if DATABASE_URL.startswith("sqlite"):
         connect_args={"check_same_thread": False},
         echo=False,
     )
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
 else:
     # For PostgreSQL/MySQL, use a larger pool to handle concurrency
     engine = create_engine(
@@ -198,3 +204,36 @@ class UserTokenDB(Base):
     is_active = Column(Boolean, default=True, nullable=False)
     last_used_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+
+class WatchlistItemDB(Base):
+    """User watchlist items."""
+    __tablename__ = "watchlist_items"
+
+    id = Column(String(36), primary_key=True)
+    user_id = Column(String(64), index=True, nullable=False)
+    symbol = Column(String(20), nullable=False)
+    sort_order = Column(Integer, default=0)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (UniqueConstraint('user_id', 'symbol', name='uq_watchlist_user_symbol'),)
+
+
+class ScheduledAnalysisDB(Base):
+    """Scheduled daily analysis tasks."""
+    __tablename__ = "scheduled_analyses"
+
+    id = Column(String(36), primary_key=True)
+    user_id = Column(String(64), index=True, nullable=False)
+    symbol = Column(String(20), nullable=False)
+    horizon = Column(String(10), default="short")        # "short" 或 "medium"，单选
+    trigger_time = Column(String(5), default="20:00")     # HH:MM 格式，允许 20:00~08:00
+    is_active = Column(Boolean, default=True)
+    last_run_date = Column(String(10), nullable=True)
+    last_run_status = Column(String(10), nullable=True)
+    last_report_id = Column(String(36), nullable=True)
+    consecutive_failures = Column(Integer, default=0)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (UniqueConstraint('user_id', 'symbol', name='uq_scheduled_user_symbol'),)

--- a/api/logging_config.yaml
+++ b/api/logging_config.yaml
@@ -1,0 +1,34 @@
+version: 1
+disable_existing_loggers: false
+formatters:
+  default:
+    "()": uvicorn.logging.DefaultFormatter
+    format: "[%(asctime)s] %(levelname)s: %(message)s"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+  access:
+    "()": uvicorn.logging.AccessFormatter
+    format: "[%(asctime)s] %(levelname)s: %(client_addr)s - \"%(request_line)s\" %(status_code)s"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+handlers:
+  default:
+    formatter: default
+    class: logging.StreamHandler
+    stream: ext://sys.stderr
+  access:
+    formatter: access
+    class: logging.StreamHandler
+    stream: ext://sys.stdout
+loggers:
+  uvicorn:
+    handlers: [default]
+    level: INFO
+    propagate: false
+  uvicorn.error:
+    level: INFO
+  uvicorn.access:
+    handlers: [access]
+    level: INFO
+    propagate: false
+root:
+  level: INFO
+  handlers: [default]

--- a/api/main.py
+++ b/api/main.py
@@ -21,7 +21,7 @@ import time
 
 # Configure standard logging to include timestamps
 logging.basicConfig(
-    level=logging.INFO,
+    level=getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO),
     format='[%(asctime)s] %(levelname)s: %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
@@ -39,8 +39,8 @@ from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy.orm import Session
 import pandas as pd
 
-from api.database import UserDB, init_db, get_db, SessionLocal
-from api.services import auth_service, report_service, token_service
+from api.database import UserDB, UserLLMConfigDB, init_db, get_db, SessionLocal
+from api.services import auth_service, report_service, token_service, watchlist_service, scheduled_service
 
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.graph.trading_graph import TradingAgentsGraph
@@ -72,13 +72,131 @@ def _cors_allow_origin_regex() -> str | None:
     return raw or None
 
 
+_scheduler_task: Optional[asyncio.Task] = None
+
+
+async def _scheduler_loop():
+    """Background loop: check every minute for scheduled tasks to trigger.
+
+    Each task has its own trigger_time (HH:MM). The scheduler runs on trading
+    days only, outside of trading hours (before 9:15 or after 15:00). Tasks
+    are triggered when current time >= task.trigger_time and the task hasn't
+    run today yet.
+    """
+    from tradingagents.dataflows.trade_calendar import is_cn_trading_day
+    from zoneinfo import ZoneInfo
+
+    _log("[Scheduler] Started.")
+    while True:
+        await asyncio.sleep(60)
+        try:
+            now = datetime.now(tz=ZoneInfo("Asia/Shanghai"))
+            today = now.strftime("%Y-%m-%d")
+            current_hhmm = now.strftime("%H:%M")
+
+            if not is_cn_trading_day(today):
+                continue
+            time_val = now.hour * 60 + now.minute
+            if 8 * 60 < time_val < 20 * 60:
+                continue
+
+            db = SessionLocal()
+            try:
+                tasks = scheduled_service.get_pending_tasks(db, today, current_hhmm)
+                if not tasks:
+                    continue
+
+                # 先标记为"已触发"防止下次循环重复启动
+                for task in tasks:
+                    task.last_run_date = today
+                    task.last_run_status = "running"
+                db.commit()
+
+                _log(f"[Scheduler] Launching {len(tasks)} tasks")
+                for task in tasks:
+                    _create_tracked_task(_run_scheduled_job(task, today))
+            finally:
+                db.close()
+
+        except Exception as e:
+            logger.error(f"[Scheduler] Error: {e}")
+
+
+async def _run_scheduled_job(task, trade_date: str):
+    """Execute a single scheduled analysis job with optional shared data collector."""
+    _log(f"[Scheduler] Running {task.symbol} for user={task.user_id}")
+    job_id = uuid4().hex
+    try:
+        _ensure_job_event_queue(job_id)
+
+        # Load user LLM config
+        db = SessionLocal()
+        try:
+            user_config = db.query(UserLLMConfigDB).filter(
+                UserLLMConfigDB.user_id == task.user_id
+            ).first()
+        finally:
+            db.close()
+
+        # 使用最近交易日（非交易日时回退到上一个交易日）
+        from tradingagents.dataflows.trade_calendar import is_cn_trading_day, previous_cn_trading_day
+        actual_trade_date = trade_date if is_cn_trading_day(trade_date) else previous_cn_trading_day(trade_date)
+        _log(f"[Scheduler] {task.symbol} trade_date={actual_trade_date} (requested={trade_date})")
+
+        horizon = task.horizon or "short"
+        req = AnalyzeRequest(
+            symbol=task.symbol,
+            trade_date=actual_trade_date,
+            horizons=[horizon],
+            query=f"定时分析 {task.symbol}",
+            # 直接设置 user_intent，跳过 LLM 意图解析（省 30+ 秒）
+            user_intent={
+                "ticker": task.symbol,
+                "horizons": [horizon],
+                "focus_areas": [],
+                "specific_questions": [],
+                "user_context": {},
+            },
+        )
+
+        await _run_job(job_id, req, user_id=task.user_id)
+
+        # Mark success
+        db = SessionLocal()
+        try:
+            scheduled_service.mark_run_success(db, task.id, trade_date, job_id)
+        finally:
+            db.close()
+        _log(f"[Scheduler] Completed {task.symbol}")
+
+    except Exception as e:
+        import traceback
+        logger.error(f"[Scheduler] Failed {task.symbol}: {e}\n{traceback.format_exc()}")
+        db = SessionLocal()
+        try:
+            scheduled_service.mark_run_failed(db, task.id, trade_date)
+        finally:
+            db.close()
+    finally:
+        _job_events.pop(job_id, None)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize resources on startup and cleanup on shutdown."""
+    global _scheduler_task
     init_db()
     _log("Database initialized.")
+    # Pre-load trade calendar (uses mini_racer/V8 which is not thread-safe)
+    # Must be called once in main thread before any concurrent analysis
+    from tradingagents.dataflows.trade_calendar import _load_cn_trade_dates
+    _load_cn_trade_dates()
+    _log("Trade calendar pre-loaded.")
+    _scheduler_task = asyncio.create_task(_scheduler_loop())
     yield
     _log("Shutting down: Cleaning up resources...")
+    if _scheduler_task:
+        _scheduler_task.cancel()
     _executor.shutdown(wait=True)
     _log("Executor shutdown complete.")
 
@@ -142,13 +260,21 @@ def _serialize_datetime_utc(value: Optional[datetime]) -> Optional[str]:
     return value.isoformat()
 
 
+_cn_stock_map_loaded_at: float = 0  # timestamp of last load
+_STOCK_MAP_TTL = 7 * 86400  # 7 days
+
+
 def _load_cn_stock_map() -> Dict[str, str]:
-    """Lazy-load and cache akshare A-share name→code mapping."""
-    global _cn_stock_map
+    """Lazy-load and cache akshare A-share name→code mapping with 7-day TTL."""
+    global _cn_stock_map, _cn_stock_map_loaded_at
+    import time as _time
+    now = _time.time()
+    if _cn_stock_map is not None and (now - _cn_stock_map_loaded_at) > _STOCK_MAP_TTL:
+        _cn_stock_map = None  # expire cache
     if _cn_stock_map is not None:
         return _cn_stock_map
     with _cn_stock_map_lock:
-        if _cn_stock_map is not None:
+        if _cn_stock_map is not None and (now - _cn_stock_map_loaded_at) <= _STOCK_MAP_TTL:
             return _cn_stock_map
         try:
             import akshare as ak
@@ -161,11 +287,19 @@ def _load_cn_stock_map() -> Dict[str, str]:
                     normalized = _normalize_symbol(code)
                     result[name] = normalized
             _cn_stock_map = result
+            _cn_stock_map_loaded_at = now
             _log(f"[StockMap] Loaded {len(result)} A-share stocks.")
         except Exception as e:
             _log(f"[StockMap] Failed to load: {e}")
-            _cn_stock_map = {}
+            if _cn_stock_map is None:
+                _cn_stock_map = {}
     return _cn_stock_map
+
+
+def _get_reverse_stock_map() -> Dict[str, str]:
+    """Return code→name mapping."""
+    name_to_code = _load_cn_stock_map()
+    return {v: k for k, v in name_to_code.items()}
 
 
 def _search_cn_stock_by_name(query: str) -> Optional[str]:
@@ -1240,9 +1374,6 @@ async def _run_job(
                     try:
                         async for chunk in horizon_graph.graph.astream(init_state, **h_args):
                             horizon_final = chunk
-                            active_keys = [k for k, v in chunk.items() if v and k != "messages"]
-                            if active_keys:
-                                logger.debug(f"[Graph Chunk/{horizon}] keys={active_keys}")
 
                             # ── 并行感知的状态推进 ──────────────────
                             # 1. 每个 analyst 报告首次出现 → completed
@@ -1505,11 +1636,6 @@ async def _run_job(
                     if db_updates:
                         await asyncio.to_thread(report_service.update_report_partial, db, job_id, **db_updates)
                     
-                    # 打印当前 chunk 包含哪些 key，方便追踪 agent 执行进度
-                    active_keys = [k for k, v in chunk.items() if v and k != "messages"]
-                    if active_keys:
-                        logger.debug(f"[Graph Chunk] keys={active_keys}")
-
                     # ── Message & Tool Call Handling ──
                     messages = chunk.get("messages", [])
                     if messages:
@@ -2798,6 +2924,154 @@ def update_runtime_config(
     }
 
 
+# ── Stock Search ──────────────────────────────────────────────────────────────
+
+@app.get("/v1/market/stock-search")
+def search_stocks(
+    q: str = Query("", min_length=1, max_length=20),
+    current_user: UserDB = Depends(_require_api_user),
+):
+    """Search stocks by code prefix or name substring."""
+    q = q.strip()
+    if not q:
+        return {"results": []}
+
+    name_to_code = _load_cn_stock_map()
+    code_to_name = _get_reverse_stock_map()
+    results = []
+    q_upper = q.upper()
+
+    for code, name in code_to_name.items():
+        if code.upper().startswith(q_upper) or code.split(".")[0].startswith(q):
+            results.append({"symbol": code, "name": name})
+            if len(results) >= 20:
+                break
+
+    if len(results) < 20:
+        for name, code in name_to_code.items():
+            if q in name and not any(r["symbol"] == code for r in results):
+                results.append({"symbol": code, "name": name})
+                if len(results) >= 20:
+                    break
+
+    return {"results": results}
+
+
+# ── Watchlist ─────────────────────────────────────────────────────────────────
+
+@app.get("/v1/watchlist")
+def list_watchlist(
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    items = watchlist_service.list_watchlist(db, current_user.id)
+    code_to_name = _get_reverse_stock_map()
+    for item in items:
+        item["name"] = code_to_name.get(item["symbol"], item["symbol"])
+    return {"items": items}
+
+
+@app.post("/v1/watchlist", status_code=201)
+def add_to_watchlist(
+    body: dict,
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    symbol = body.get("symbol", "").strip().upper()
+    if not symbol:
+        raise HTTPException(400, "symbol is required")
+    code_to_name = _get_reverse_stock_map()
+    if symbol not in code_to_name:
+        raise HTTPException(400, f"未知的股票代码: {symbol}")
+    try:
+        item = watchlist_service.add_watchlist_item(db, current_user.id, symbol)
+        item["name"] = code_to_name.get(symbol, symbol)
+        return item
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+@app.delete("/v1/watchlist/{item_id}", status_code=204)
+def delete_from_watchlist(
+    item_id: str,
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    if not watchlist_service.delete_watchlist_item(db, current_user.id, item_id):
+        raise HTTPException(404, "未找到该自选股")
+
+
+# ── Scheduled Analysis ────────────────────────────────────────────────────────
+
+@app.get("/v1/scheduled")
+def list_scheduled_analyses(
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    items = scheduled_service.list_scheduled(db, current_user.id)
+    code_to_name = _get_reverse_stock_map()
+    for item in items:
+        item["name"] = code_to_name.get(item["symbol"], item["symbol"])
+    return {"items": items}
+
+
+@app.post("/v1/scheduled", status_code=201)
+def create_scheduled_analysis(
+    body: dict,
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    symbol = body.get("symbol", "").strip().upper()
+    horizon = body.get("horizon", "short")
+    trigger_time = body.get("trigger_time", "20:00")
+    if not symbol:
+        raise HTTPException(400, "symbol is required")
+    code_to_name = _get_reverse_stock_map()
+    if symbol not in code_to_name:
+        raise HTTPException(400, f"未知的股票代码: {symbol}")
+    try:
+        item = scheduled_service.create_scheduled(db, current_user.id, symbol, horizon, trigger_time)
+        item["name"] = code_to_name.get(symbol, symbol)
+        return item
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+
+
+@app.patch("/v1/scheduled/{item_id}")
+def update_scheduled_analysis(
+    item_id: str,
+    body: dict,
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    kwargs = {}
+    if "is_active" in body:
+        kwargs["is_active"] = bool(body["is_active"])
+    if "horizon" in body:
+        kwargs["horizon"] = body["horizon"]
+    if "trigger_time" in body:
+        kwargs["trigger_time"] = body["trigger_time"]
+    try:
+        result = scheduled_service.update_scheduled(db, current_user.id, item_id, **kwargs)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    if result is None:
+        raise HTTPException(404, "未找到该定时任务")
+    code_to_name = _get_reverse_stock_map()
+    result["name"] = code_to_name.get(result["symbol"], result["symbol"])
+    return result
+
+
+@app.delete("/v1/scheduled/{item_id}", status_code=204)
+def delete_scheduled_analysis(
+    item_id: str,
+    current_user: UserDB = Depends(_require_api_user),
+    db: Session = Depends(get_db),
+):
+    if not scheduled_service.delete_scheduled(db, current_user.id, item_id):
+        raise HTTPException(404, "未找到该定时任务")
+
+
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 
@@ -2831,5 +3105,7 @@ if os.path.exists(dist_path):
 
 def run() -> None:
     import uvicorn
+    from pathlib import Path
 
-    uvicorn.run("api.main:app", host="0.0.0.0", port=8000, reload=False)
+    log_config = str(Path(__file__).parent / "logging_config.yaml")
+    uvicorn.run("api.main:app", host="0.0.0.0", port=8000, reload=False, log_config=log_config)

--- a/api/services/report_service.py
+++ b/api/services/report_service.py
@@ -2,7 +2,10 @@
 
 import json
 import json_repair
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, Literal
 from uuid import uuid4
@@ -16,16 +19,39 @@ from api.database import ReportDB
 
 # ─── Structured extraction schemas ───────────────────────────────────────────
 
+from pydantic import field_validator
+
+
 class RiskItemSchema(BaseModel):
     name: str = Field(..., description="风险名称，15字以内")
-    level: Literal["high", "medium", "low"] = Field(..., description="风险等级")
+    level: str = Field("medium", description="风险等级")
     description: str = Field("", description="一句话说明，30字以内")
+
+    @field_validator("level", mode="before")
+    @classmethod
+    def _coerce_level(cls, v):
+        if isinstance(v, str) and v.lower() in ("high", "medium", "low"):
+            return v.lower()
+        return "medium"
 
 
 class KeyMetricSchema(BaseModel):
     name: str = Field(..., description="指标名称，如 PE、ROE、营收增速")
     value: str = Field(..., description="指标值，包含单位，如 28.5x、15.2%")
-    status: Literal["good", "neutral", "bad"] = Field("neutral", description="优劣判断")
+    status: str = Field("neutral", description="优劣判断")
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _coerce_value(cls, v):
+        # LLM 可能返回数字而非字符串
+        return str(v) if not isinstance(v, str) else v
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _coerce_status(cls, v):
+        if isinstance(v, str) and v.lower() in ("good", "neutral", "bad"):
+            return v.lower()
+        return "neutral"
 
 
 class StructuredReport(BaseModel):
@@ -35,6 +61,14 @@ class StructuredReport(BaseModel):
     stop_loss_price: Optional[float] = Field(None, description="止损价（数字，无单位）")
     risks: List[RiskItemSchema] = Field(default_factory=list, description="主要风险，最多5条")
     key_metrics: List[KeyMetricSchema] = Field(default_factory=list, description="关键指标，最多6条")
+
+    @field_validator("target_price", "stop_loss_price", mode="before")
+    @classmethod
+    def _coerce_price(cls, v):
+        # LLM 可能返回数组 [34.0, 32.5] 而非单个数字，取第一个
+        if isinstance(v, list):
+            return v[0] if v else None
+        return v
 
 
 def extract_structured_data(
@@ -77,12 +111,13 @@ def extract_structured_data(
         raw = response.content if hasattr(response, "content") else str(response)
         parsed = json_repair.loads(raw)
         result = StructuredReport(**parsed)
-        # 置信度范围校验
         if result.confidence is not None and not (0 <= result.confidence <= 100):
             result.confidence = None
         return result
     except Exception as e:
-        print(f"[report_service] LLM structured extraction failed: {e}")
+        logger.warning(f"LLM structured extraction failed: {e}")
+        if 'raw' in locals():
+            logger.warning(f"Raw LLM output:\n{raw}")
         return None
 
 

--- a/api/services/scheduled_service.py
+++ b/api/services/scheduled_service.py
@@ -1,0 +1,174 @@
+"""Scheduled analysis service for database operations."""
+
+from typing import List, Optional
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from api.database import ScheduledAnalysisDB
+
+MAX_SCHEDULED_ITEMS = 10
+
+# 非交易时间窗口：15:00~次日9:15 允许设置
+VALID_HORIZONS = {"short", "medium"}
+
+
+def _validate_trigger_time(t: str) -> str:
+    """Validate HH:MM format. Allowed: 20:00~23:59 or 00:00~08:00."""
+    parts = t.strip().split(":")
+    if len(parts) != 2:
+        raise ValueError("时间格式错误，请使用 HH:MM")
+    try:
+        hh, mm = int(parts[0]), int(parts[1])
+    except ValueError:
+        raise ValueError("时间格式错误，请使用 HH:MM")
+    if not (0 <= hh <= 23 and 0 <= mm <= 59):
+        raise ValueError("时间格式错误，请使用 HH:MM")
+    time_val = hh * 60 + mm
+    # Allowed: 20:00 (1200) ~ 23:59 (1439) or 00:00 (0) ~ 08:00 (480)
+    if 8 * 60 < time_val < 20 * 60:
+        raise ValueError("定时时间仅允许 20:00~次日 08:00（避免影响白天使用）")
+    return f"{hh:02d}:{mm:02d}"
+
+
+def list_scheduled(db: Session, user_id: str) -> List[dict]:
+    """List user's scheduled analysis tasks."""
+    items = (
+        db.query(ScheduledAnalysisDB)
+        .filter(ScheduledAnalysisDB.user_id == user_id)
+        .order_by(ScheduledAnalysisDB.created_at)
+        .all()
+    )
+    return [_to_dict(item) for item in items]
+
+
+def create_scheduled(
+    db: Session,
+    user_id: str,
+    symbol: str,
+    horizon: str = "short",
+    trigger_time: str = "20:00",
+) -> dict:
+    """Create a scheduled analysis task."""
+    count = db.query(ScheduledAnalysisDB).filter(
+        ScheduledAnalysisDB.user_id == user_id
+    ).count()
+    if count >= MAX_SCHEDULED_ITEMS:
+        raise ValueError(f"定时分析数量已达上限 ({MAX_SCHEDULED_ITEMS})")
+
+    existing = (
+        db.query(ScheduledAnalysisDB)
+        .filter(ScheduledAnalysisDB.user_id == user_id, ScheduledAnalysisDB.symbol == symbol)
+        .first()
+    )
+    if existing:
+        raise ValueError(f"{symbol} 已有定时分析任务")
+
+    if horizon not in VALID_HORIZONS:
+        raise ValueError(f"horizon 必须为 short 或 medium")
+
+    trigger_time = _validate_trigger_time(trigger_time)
+
+    item = ScheduledAnalysisDB(
+        id=uuid4().hex,
+        user_id=user_id,
+        symbol=symbol,
+        horizon=horizon,
+        trigger_time=trigger_time,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return _to_dict(item)
+
+
+def update_scheduled(db: Session, user_id: str, item_id: str, **kwargs) -> Optional[dict]:
+    """Update a scheduled analysis task. Returns None if not found."""
+    item = (
+        db.query(ScheduledAnalysisDB)
+        .filter(ScheduledAnalysisDB.id == item_id, ScheduledAnalysisDB.user_id == user_id)
+        .first()
+    )
+    if not item:
+        return None
+
+    if "is_active" in kwargs:
+        item.is_active = kwargs["is_active"]
+        if kwargs["is_active"]:
+            item.consecutive_failures = 0
+    if "horizon" in kwargs:
+        if kwargs["horizon"] not in VALID_HORIZONS:
+            raise ValueError("horizon 必须为 short 或 medium")
+        item.horizon = kwargs["horizon"]
+    if "trigger_time" in kwargs:
+        item.trigger_time = _validate_trigger_time(kwargs["trigger_time"])
+
+    db.commit()
+    db.refresh(item)
+    return _to_dict(item)
+
+
+def delete_scheduled(db: Session, user_id: str, item_id: str) -> bool:
+    """Delete a scheduled analysis task."""
+    item = (
+        db.query(ScheduledAnalysisDB)
+        .filter(ScheduledAnalysisDB.id == item_id, ScheduledAnalysisDB.user_id == user_id)
+        .first()
+    )
+    if not item:
+        return False
+    db.delete(item)
+    db.commit()
+    return True
+
+
+def get_pending_tasks(db: Session, today: str, current_hhmm: str) -> List[ScheduledAnalysisDB]:
+    """Get all active tasks that haven't run today and whose trigger time has passed."""
+    all_active = (
+        db.query(ScheduledAnalysisDB)
+        .filter(
+            ScheduledAnalysisDB.is_active == True,
+            (ScheduledAnalysisDB.last_run_date != today) | (ScheduledAnalysisDB.last_run_date == None),
+        )
+        .all()
+    )
+    # Filter by trigger_time <= current_hhmm
+    return [t for t in all_active if (t.trigger_time or "20:00") <= current_hhmm]
+
+
+def mark_run_success(db: Session, item_id: str, trade_date: str, report_id: str):
+    """Mark a scheduled task as successfully run."""
+    item = db.query(ScheduledAnalysisDB).filter(ScheduledAnalysisDB.id == item_id).first()
+    if item:
+        item.last_run_date = trade_date
+        item.last_run_status = "success"
+        item.last_report_id = report_id
+        item.consecutive_failures = 0
+        db.commit()
+
+
+def mark_run_failed(db: Session, item_id: str, trade_date: str):
+    """Mark a scheduled task as failed. Auto-deactivate after 3 consecutive failures."""
+    item = db.query(ScheduledAnalysisDB).filter(ScheduledAnalysisDB.id == item_id).first()
+    if item:
+        item.last_run_date = trade_date
+        item.last_run_status = "failed"
+        item.consecutive_failures = (item.consecutive_failures or 0) + 1
+        if item.consecutive_failures >= 3:
+            item.is_active = False
+        db.commit()
+
+
+def _to_dict(item: ScheduledAnalysisDB) -> dict:
+    return {
+        "id": item.id,
+        "symbol": item.symbol,
+        "horizon": item.horizon or "short",
+        "trigger_time": item.trigger_time or "15:30",
+        "is_active": item.is_active,
+        "last_run_date": item.last_run_date,
+        "last_run_status": item.last_run_status,
+        "last_report_id": item.last_report_id,
+        "consecutive_failures": item.consecutive_failures,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+    }

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -1,0 +1,76 @@
+"""Watchlist service for database operations."""
+
+from typing import List
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from api.database import WatchlistItemDB, ScheduledAnalysisDB
+
+MAX_WATCHLIST_ITEMS = 50
+
+
+def list_watchlist(db: Session, user_id: str) -> List[dict]:
+    """List user's watchlist items with scheduled status."""
+    items = (
+        db.query(WatchlistItemDB)
+        .filter(WatchlistItemDB.user_id == user_id)
+        .order_by(WatchlistItemDB.sort_order, WatchlistItemDB.created_at)
+        .all()
+    )
+    scheduled_symbols = set(
+        row.symbol for row in
+        db.query(ScheduledAnalysisDB.symbol)
+        .filter(ScheduledAnalysisDB.user_id == user_id)
+        .all()
+    )
+    return [
+        {
+            "id": item.id,
+            "symbol": item.symbol,
+            "sort_order": item.sort_order,
+            "created_at": item.created_at.isoformat() if item.created_at else None,
+            "has_scheduled": item.symbol in scheduled_symbols,
+        }
+        for item in items
+    ]
+
+
+def add_watchlist_item(db: Session, user_id: str, symbol: str) -> dict:
+    """Add a stock to user's watchlist."""
+    count = db.query(WatchlistItemDB).filter(WatchlistItemDB.user_id == user_id).count()
+    if count >= MAX_WATCHLIST_ITEMS:
+        raise ValueError(f"自选股数量已达上限 ({MAX_WATCHLIST_ITEMS})")
+
+    existing = (
+        db.query(WatchlistItemDB)
+        .filter(WatchlistItemDB.user_id == user_id, WatchlistItemDB.symbol == symbol)
+        .first()
+    )
+    if existing:
+        raise ValueError(f"{symbol} 已在自选列表中")
+
+    item = WatchlistItemDB(id=uuid4().hex, user_id=user_id, symbol=symbol)
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return {
+        "id": item.id,
+        "symbol": item.symbol,
+        "sort_order": item.sort_order,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+    }
+
+
+def delete_watchlist_item(db: Session, user_id: str, item_id: str) -> bool:
+    """Delete a watchlist item. Returns True if found and deleted."""
+    item = (
+        db.query(WatchlistItemDB)
+        .filter(WatchlistItemDB.id == item_id, WatchlistItemDB.user_id == user_id)
+        .first()
+    )
+    if not item:
+        return False
+    db.delete(item)
+    db.commit()
+    return True

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -13,7 +13,7 @@ const navItems = [
     { path: '/', icon: LayoutDashboard, label: '控制台' },
     { path: '/analysis', icon: Activity, label: '智能分析' },
     { path: '/reports', icon: FileText, label: '历史报告' },
-    { path: '/portfolio', icon: Briefcase, label: '自选股' },
+    { path: '/portfolio', icon: Briefcase, label: '自选 & 定时' },
     { path: '/settings', icon: Settings, label: '设置' },
 ]
 

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,174 +1,263 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Briefcase, Plus, Trash2, TrendingUp, Activity, Flame, RefreshCw, TrendingDown } from 'lucide-react'
+import {
+    Briefcase, Plus, Trash2, TrendingUp, Activity, Search,
+    Clock, AlertTriangle, CheckCircle2, XCircle, Loader2, Timer,
+} from 'lucide-react'
 import { api } from '@/services/api'
-import type { Report, HotStock } from '@/types'
+import type { WatchlistItem, ScheduledAnalysis, StockSearchResult, Report } from '@/types'
 
-interface Holding {
-    symbol: string
-    notes: string
-    addedAt: string
-}
-
-const STORAGE_KEY = 'ta-portfolio'
-
-function loadHoldings(): Holding[] {
-    try {
-        return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') as Holding[]
-    } catch {
-        return []
-    }
-}
-
-function saveHoldings(holdings: Holding[]) {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(holdings))
-}
-
-const parseDecisionColor = (decision?: string) => {
-    if (!decision) return 'text-slate-400'
-    const d = decision.toUpperCase()
-    if (d.includes('BUY') || d.includes('增持') || d.includes('买入')) return 'text-red-500'
-    if (d.includes('SELL') || d.includes('减持') || d.includes('卖出')) return 'text-green-500'
-    return 'text-slate-500 dark:text-slate-400'
-}
-
-const parseDecisionLabel = (decision?: string) => {
-    if (!decision) return '暂无'
-    const d = decision.toUpperCase()
-    if (d.includes('BUY') || d.includes('增持') || d.includes('买入')) return '增持'
-    if (d.includes('SELL') || d.includes('减持') || d.includes('卖出')) return '减持'
-    return '持有'
-}
+const HORIZON_LABELS: Record<string, string> = { short: '短线', medium: '中线' }
 
 export default function Portfolio() {
-    const [holdings, setHoldings] = useState<Holding[]>(loadHoldings)
-    const [newSymbol, setNewSymbol] = useState('')
-    const [newNotes, setNewNotes] = useState('')
+    const [watchlist, setWatchlist] = useState<WatchlistItem[]>([])
+    const [scheduled, setScheduled] = useState<ScheduledAnalysis[]>([])
     const [latestReports, setLatestReports] = useState<Record<string, Report>>({})
-    const [hotStocks, setHotStocks] = useState<HotStock[]>([])
-    const [hotLoading, setHotLoading] = useState(false)
-    const [hotSource, setHotSource] = useState<'em' | 'xq' | 'ths'>('em')
+    const [loading, setLoading] = useState(true)
+
+    // Search state
+    const [searchQuery, setSearchQuery] = useState('')
+    const [searchResults, setSearchResults] = useState<StockSearchResult[]>([])
+    const [searchLoading, setSearchLoading] = useState(false)
+    const [showDropdown, setShowDropdown] = useState(false)
+    const searchTimerRef = useRef<ReturnType<typeof setTimeout>>()
+    const dropdownRef = useRef<HTMLDivElement>(null)
+
     const navigate = useNavigate()
 
+    const fetchAll = async () => {
+        setLoading(true)
+        try {
+            const [wRes, sRes] = await Promise.all([
+                api.getWatchlist(),
+                api.getScheduled(),
+            ])
+            setWatchlist(wRes.items)
+            setScheduled(sRes.items)
+
+            // Fetch latest report for each watchlist symbol
+            const reportMap: Record<string, Report> = {}
+            await Promise.all(
+                wRes.items.map(async (item) => {
+                    try {
+                        const res = await api.getReports(item.symbol, 0, 1)
+                        if (res.reports.length > 0) reportMap[item.symbol] = res.reports[0]
+                    } catch {}
+                })
+            )
+            setLatestReports(reportMap)
+        } catch {}
+        setLoading(false)
+    }
+
+    useEffect(() => { fetchAll() }, [])
+
+    // Close dropdown on outside click
     useEffect(() => {
-        holdings.forEach(h => {
-            api.getReports(h.symbol, 0, 1).then(res => {
-                if (res.reports.length > 0) {
-                    setLatestReports(prev => ({ ...prev, [h.symbol]: res.reports[0] }))
-                }
-            }).catch(() => {})
-        })
-    }, [holdings])
+        const handler = (e: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+                setShowDropdown(false)
+            }
+        }
+        document.addEventListener('mousedown', handler)
+        return () => document.removeEventListener('mousedown', handler)
+    }, [])
 
-    const fetchHotStocks = (source = hotSource) => {
-        setHotLoading(true)
-        api.getHotStocks(30, source)
-            .then(res => setHotStocks(res.stocks))
-            .catch(() => {})
-            .finally(() => setHotLoading(false))
+    // Debounced search
+    useEffect(() => {
+        if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
+        if (!searchQuery.trim()) {
+            setSearchResults([])
+            setShowDropdown(false)
+            return
+        }
+        setSearchLoading(true)
+        searchTimerRef.current = setTimeout(async () => {
+            try {
+                const res = await api.searchStocks(searchQuery.trim())
+                setSearchResults(res.results)
+                setShowDropdown(true)
+            } catch {}
+            setSearchLoading(false)
+        }, 300)
+    }, [searchQuery])
+
+    const addToWatchlist = async (symbol: string) => {
+        try {
+            await api.addToWatchlist(symbol)
+            setSearchQuery('')
+            setShowDropdown(false)
+            fetchAll()
+        } catch (e) {
+            alert(e instanceof Error ? e.message : '添加失败')
+        }
     }
 
-    useEffect(() => { fetchHotStocks(hotSource) }, [hotSource])
-
-    const addHolding = (symbol?: string, notes?: string) => {
-        const sym = (symbol ?? newSymbol).trim().toUpperCase()
-        if (!sym || holdings.some(h => h.symbol === sym)) return
-        const updated = [...holdings, { symbol: sym, notes: (notes ?? newNotes).trim(), addedAt: new Date().toISOString() }]
-        setHoldings(updated)
-        saveHoldings(updated)
-        if (!symbol) { setNewSymbol(''); setNewNotes('') }
+    const removeFromWatchlist = async (id: string) => {
+        try {
+            await api.removeFromWatchlist(id)
+            fetchAll()
+        } catch {}
     }
 
-    const removeHolding = (symbol: string) => {
-        const updated = holdings.filter(h => h.symbol !== symbol)
-        setHoldings(updated)
-        saveHoldings(updated)
+    const toggleScheduled = async (symbol: string, hasScheduled: boolean) => {
+        try {
+            if (hasScheduled) {
+                const task = scheduled.find(s => s.symbol === symbol)
+                if (task) await api.deleteScheduled(task.id)
+            } else {
+                await api.createScheduled(symbol, 'short', '20:00')
+            }
+            fetchAll()
+        } catch (e) {
+            alert(e instanceof Error ? e.message : '操作失败')
+        }
+    }
+
+    const updateScheduledHorizon = async (id: string, horizon: string) => {
+        try {
+            await api.updateScheduled(id, { horizon })
+            fetchAll()
+        } catch {}
+    }
+
+    const updateScheduledTime = async (id: string, trigger_time: string) => {
+        try {
+            await api.updateScheduled(id, { trigger_time })
+            fetchAll()
+        } catch (e) {
+            alert(e instanceof Error ? e.message : '时间设置失败（需在交易时段外）')
+        }
+    }
+
+    const toggleScheduledActive = async (id: string, active: boolean) => {
+        try {
+            await api.updateScheduled(id, { is_active: active })
+            fetchAll()
+        } catch {}
+    }
+
+    const deleteScheduledTask = async (id: string) => {
+        try {
+            await api.deleteScheduled(id)
+            fetchAll()
+        } catch {}
+    }
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-20">
+                <Loader2 className="w-6 h-6 animate-spin text-blue-500" />
+            </div>
+        )
     }
 
     return (
         <div className="space-y-6">
             <div>
-                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">自选股 &amp; 热榜选股</h1>
-                <p className="text-slate-500 dark:text-slate-400 mt-1">管理关注标的，从热榜快速发起分析</p>
+                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">自选 & 定时分析</h1>
+                <p className="text-slate-500 dark:text-slate-400 mt-1">管理关注标的，开启每日定时自动分析</p>
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 {/* Left: Watchlist */}
                 <div className="space-y-4">
-                    {/* Add stock */}
+                    {/* Stock search */}
                     <div className="card space-y-3">
                         <div className="flex items-center gap-2">
                             <Plus className="w-5 h-5 text-blue-500" />
                             <h2 className="font-semibold text-slate-900 dark:text-slate-100">添加自选</h2>
                         </div>
-                        <div className="flex gap-2">
-                            <input
-                                value={newSymbol}
-                                onChange={e => setNewSymbol(e.target.value)}
-                                onKeyDown={e => e.key === 'Enter' && addHolding()}
-                                placeholder="代码，如 600519.SH"
-                                className="input flex-1"
-                                maxLength={20}
-                            />
-                            <input
-                                value={newNotes}
-                                onChange={e => setNewNotes(e.target.value)}
-                                placeholder="备注"
-                                className="input flex-1"
-                                maxLength={100}
-                            />
-                            <button onClick={() => addHolding()} className="btn-primary px-4">
-                                <Plus className="w-4 h-4" />
-                            </button>
+                        <div className="relative" ref={dropdownRef}>
+                            <div className="flex items-center gap-2">
+                                <div className="relative flex-1">
+                                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                                    <input
+                                        value={searchQuery}
+                                        onChange={e => setSearchQuery(e.target.value)}
+                                        onFocus={() => searchResults.length > 0 && setShowDropdown(true)}
+                                        placeholder="搜索代码或名称，如 300750 或 宁德时代"
+                                        className="input pl-9 w-full"
+                                        maxLength={20}
+                                    />
+                                    {searchLoading && <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-slate-400" />}
+                                </div>
+                            </div>
+
+                            {/* Search dropdown */}
+                            {showDropdown && searchResults.length > 0 && (
+                                <div className="absolute z-50 w-full mt-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                                    {searchResults.map(r => (
+                                        <button
+                                            key={r.symbol}
+                                            onClick={() => addToWatchlist(r.symbol)}
+                                            className="w-full flex items-center gap-3 px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
+                                        >
+                                            <span className="text-sm font-medium text-slate-900 dark:text-slate-100">{r.name}</span>
+                                            <span className="text-xs text-slate-400">{r.symbol}</span>
+                                            <Plus className="w-3.5 h-3.5 text-blue-500 ml-auto" />
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
                         </div>
                     </div>
 
-                    {/* Holdings list */}
+                    {/* Watchlist */}
                     <div className="card">
                         <div className="flex items-center gap-2 mb-4">
                             <Briefcase className="w-5 h-5 text-purple-500" />
-                            <h2 className="font-semibold text-slate-900 dark:text-slate-100">自选列表 ({holdings.length})</h2>
+                            <h2 className="font-semibold text-slate-900 dark:text-slate-100">自选列表 ({watchlist.length}/50)</h2>
                         </div>
 
-                        {holdings.length === 0 ? (
+                        {watchlist.length === 0 ? (
                             <div className="text-center py-10">
                                 <Briefcase className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
                                 <p className="text-slate-500 dark:text-slate-400">还没有关注的股票</p>
-                                <p className="text-sm text-slate-400 dark:text-slate-500 mt-1">从热榜添加或手动输入代码</p>
+                                <p className="text-sm text-slate-400 dark:text-slate-500 mt-1">搜索代码或名称添加</p>
                             </div>
                         ) : (
                             <div className="divide-y divide-slate-100 dark:divide-slate-700">
-                                {holdings.map(h => {
-                                    const report = latestReports[h.symbol]
+                                {watchlist.map(item => {
+                                    const report = latestReports[item.symbol]
                                     return (
-                                        <div key={h.symbol} className="flex items-center gap-3 py-3">
+                                        <div key={item.id} className="flex items-center gap-3 py-3">
                                             <div className="w-9 h-9 rounded-lg bg-blue-100 dark:bg-blue-500/10 flex items-center justify-center shrink-0">
                                                 <TrendingUp className="w-4 h-4 text-blue-600 dark:text-blue-400" />
                                             </div>
                                             <div className="flex-1 min-w-0">
-                                                <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">{h.symbol}</p>
-                                                {h.notes && <p className="text-xs text-slate-400 truncate">{h.notes}</p>}
+                                                <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">{item.name}</p>
+                                                <p className="text-xs text-slate-400">{item.symbol}</p>
                                                 {report && (
                                                     <p className="text-xs text-slate-400 mt-0.5">
-                                                        {report.trade_date}
-                                                        {report.confidence != null && ` · ${report.confidence}%`}
+                                                        最近：{report.trade_date} · {report.direction || report.decision || '—'}
                                                     </p>
                                                 )}
                                             </div>
-                                            {report && (
-                                                <span className={`text-xs font-medium ${parseDecisionColor(report.decision)}`}>
-                                                    {parseDecisionLabel(report.decision)}
-                                                </span>
-                                            )}
+                                            {/* Schedule toggle */}
                                             <button
-                                                onClick={() => navigate(`/analysis?symbol=${h.symbol}`)}
-                                                className="flex items-center gap-1 px-2.5 py-1 text-xs rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-500/20 transition-colors"
+                                                onClick={() => toggleScheduled(item.symbol, item.has_scheduled)}
+                                                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg transition-colors ${
+                                                    item.has_scheduled
+                                                        ? 'bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-100'
+                                                        : 'bg-slate-100 dark:bg-slate-700 text-slate-500 hover:bg-slate-200 dark:hover:bg-slate-600'
+                                                }`}
+                                                title={item.has_scheduled ? '已开启定时分析' : '开启定时分析'}
+                                            >
+                                                <Timer className="w-3 h-3" />
+                                                {item.has_scheduled ? '定时' : '定时'}
+                                            </button>
+                                            {/* Analyze */}
+                                            <button
+                                                onClick={() => navigate(`/analysis?symbol=${item.symbol}`)}
+                                                className="flex items-center gap-1 px-2 py-1 text-xs rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-500/20 transition-colors"
                                             >
                                                 <Activity className="w-3 h-3" />
                                                 分析
                                             </button>
+                                            {/* Delete */}
                                             <button
-                                                onClick={() => removeHolding(h.symbol)}
+                                                onClick={() => removeFromWatchlist(item.id)}
                                                 className="p-1.5 text-slate-400 hover:text-red-500 transition-colors"
                                             >
                                                 <Trash2 className="w-3.5 h-3.5" />
@@ -181,84 +270,121 @@ export default function Portfolio() {
                     </div>
                 </div>
 
-                {/* Right: Hot stocks */}
+                {/* Right: Scheduled Analysis */}
                 <div className="card">
-                    <div className="flex items-center justify-between mb-3">
-                        <div className="flex items-center gap-2">
-                            <Flame className="w-5 h-5 text-orange-500" />
-                            <h2 className="font-semibold text-slate-900 dark:text-slate-100">热榜选股</h2>
-                        </div>
-                        <button
-                            onClick={() => fetchHotStocks()}
-                            disabled={hotLoading}
-                            className="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors disabled:opacity-40"
-                        >
-                            <RefreshCw className={`w-4 h-4 ${hotLoading ? 'animate-spin' : ''}`} />
-                        </button>
+                    <div className="flex items-center gap-2 mb-4">
+                        <Clock className="w-5 h-5 text-emerald-500" />
+                        <h2 className="font-semibold text-slate-900 dark:text-slate-100">定时分析 ({scheduled.length}/10)</h2>
                     </div>
-                    <div className="flex gap-1 mb-3">
-                        {(['em', 'xq', 'ths'] as const).map(src => (
-                            <button
-                                key={src}
-                                onClick={() => setHotSource(src)}
-                                className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${hotSource === src
-                                    ? 'bg-orange-500 border-orange-500 text-white'
-                                    : 'border-slate-300 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:border-orange-400'
-                                }`}
-                            >
-                                {src === 'em' ? '东财热榜' : src === 'xq' ? '雪球热门' : '连涨榜'}
-                            </button>
-                        ))}
-                    </div>
+                    <p className="text-xs text-slate-400 mb-4">每个交易日在设定时间自动执行（允许 20:00~次日 08:00）</p>
 
-                    {hotStocks.length === 0 ? (
+                    {scheduled.length === 0 ? (
                         <div className="text-center py-10">
-                            <Flame className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
-                            <p className="text-slate-500 dark:text-slate-400">{hotLoading ? '加载中...' : '暂无数据'}</p>
+                            <Clock className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
+                            <p className="text-slate-500 dark:text-slate-400">暂无定时任务</p>
+                            <p className="text-sm text-slate-400 dark:text-slate-500 mt-1">在自选列表中点击"定时"开启</p>
                         </div>
                     ) : (
-                        <div className="divide-y divide-slate-100 dark:divide-slate-700 max-h-[500px] overflow-y-auto">
-                            {hotStocks.map(stock => (
-                                <div key={stock.symbol} className="flex items-center gap-3 py-2.5 hover:bg-slate-50 dark:hover:bg-slate-800/30 -mx-4 px-4 transition-colors">
-                                    <span className="text-xs text-slate-400 w-5 text-right shrink-0">{stock.rank}</span>
-                                    <div className="flex-1 min-w-0">
-                                        <div className="flex items-center gap-2">
-                                            <span className="font-medium text-sm text-slate-900 dark:text-slate-100">{stock.name}</span>
-                                            <span className="text-xs text-slate-400">{stock.symbol}</span>
-                                        </div>
-                                        <div className="flex items-center gap-3 mt-0.5">
-                                            <span className="text-sm text-slate-700 dark:text-slate-300">¥{(stock.price || 0).toFixed(2)}</span>
-                                            {stock.change_pct !== 0 && (
-                                                <span className={`text-xs font-medium flex items-center gap-0.5 ${(stock.change_pct || 0) >= 0 ? 'text-red-500' : 'text-green-500'}`}>
-                                                    {(stock.change_pct || 0) >= 0 ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
-                                                    {(stock.change_pct || 0) >= 0 ? '+' : ''}{(stock.change_pct || 0).toFixed(2)}%
+                        <div className="space-y-3">
+                            {scheduled.map(task => (
+                                <div
+                                    key={task.id}
+                                    className={`rounded-xl border p-3 transition-all ${
+                                        !task.is_active
+                                            ? 'border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/30 opacity-60'
+                                            : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60'
+                                    }`}
+                                >
+                                    <div className="flex items-center gap-3">
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2">
+                                                <p className="font-medium text-sm text-slate-900 dark:text-slate-100">{task.name}</p>
+                                                <span className="text-xs text-slate-400">{task.symbol}</span>
+                                            </div>
+                                            <div className="flex items-center gap-2 mt-1 flex-wrap">
+                                                {/* Horizon badge */}
+                                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400">
+                                                    {HORIZON_LABELS[task.horizon] || task.horizon}
                                                 </span>
-                                            )}
-                                            {stock.extra && (
-                                                <span className="text-xs text-slate-500 dark:text-slate-400">
-                                                    {stock.extra}
+                                                {/* Trigger time */}
+                                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex items-center gap-0.5">
+                                                    <Clock className="w-2.5 h-2.5" />
+                                                    {task.trigger_time}
                                                 </span>
+                                                {/* Last run status */}
+                                                {task.last_run_date && (
+                                                    <span className="text-[10px] text-slate-400 flex items-center gap-0.5">
+                                                        {task.last_run_status === 'success' ? (
+                                                            <CheckCircle2 className="w-3 h-3 text-emerald-500" />
+                                                        ) : task.last_run_status === 'failed' ? (
+                                                            <XCircle className="w-3 h-3 text-red-500" />
+                                                        ) : null}
+                                                        {task.last_run_date}
+                                                    </span>
+                                                )}
+                                            </div>
+                                            {task.consecutive_failures >= 3 && (
+                                                <div className="flex items-center gap-1 mt-1.5 text-[10px] text-amber-600 dark:text-amber-400">
+                                                    <AlertTriangle className="w-3 h-3" />
+                                                    连续失败 {task.consecutive_failures} 次，已自动停用
+                                                </div>
                                             )}
                                         </div>
-                                    </div>
-                                    <div className="flex items-center gap-1">
-                                        {!holdings.some(h => h.symbol === stock.symbol) && (
-                                            <button
-                                                onClick={() => addHolding(stock.symbol, stock.name)}
-                                                className="p-1.5 text-slate-400 hover:text-blue-500 transition-colors"
-                                                title="加入自选"
-                                            >
-                                                <Plus className="w-4 h-4" />
-                                            </button>
-                                        )}
+
+                                        {/* Horizon select (single) */}
+                                        <div className="flex gap-1">
+                                            {(['short', 'medium'] as const).map(h => (
+                                                <button
+                                                    key={h}
+                                                    onClick={() => updateScheduledHorizon(task.id, h)}
+                                                    className={`px-2 py-0.5 text-[10px] rounded-full border transition-colors ${
+                                                        task.horizon === h
+                                                            ? 'bg-blue-500 border-blue-500 text-white'
+                                                            : 'border-slate-300 dark:border-slate-600 text-slate-400 hover:border-blue-400'
+                                                    }`}
+                                                >
+                                                    {HORIZON_LABELS[h]}
+                                                </button>
+                                            ))}
+                                        </div>
+
+                                        {/* Time picker */}
+                                        <input
+                                            type="time"
+                                            value={task.trigger_time}
+                                            onChange={e => updateScheduledTime(task.id, e.target.value)}
+                                            className="w-[90px] text-sm px-2 py-1 rounded-lg border border-slate-300 dark:border-slate-600 bg-transparent text-slate-700 dark:text-slate-200"
+                                        />
+
+                                        {/* Active toggle */}
                                         <button
-                                            onClick={() => navigate(`/analysis?symbol=${stock.symbol}`)}
-                                            className="flex items-center gap-1 px-2 py-1 text-xs rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-500/20 transition-colors"
+                                            onClick={() => toggleScheduledActive(task.id, !task.is_active)}
+                                            className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${
+                                                task.is_active ? 'bg-emerald-500' : 'bg-slate-300 dark:bg-slate-600'
+                                            }`}
                                         >
-                                            <Activity className="w-3 h-3" />
-                                            分析
+                                            <div className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                                                task.is_active ? 'translate-x-4' : 'translate-x-0.5'
+                                            }`} />
+                                        </button>
+
+                                        {/* Delete */}
+                                        <button
+                                            onClick={() => deleteScheduledTask(task.id)}
+                                            className="p-1.5 text-slate-400 hover:text-red-500 transition-colors shrink-0"
+                                        >
+                                            <Trash2 className="w-3.5 h-3.5" />
                                         </button>
                                     </div>
+
+                                    {task.last_report_id && task.last_run_status === 'success' && (
+                                        <button
+                                            onClick={() => navigate(`/reports?report=${task.last_report_id}`)}
+                                            className="mt-2 text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
+                                        >
+                                            查看最近报告 →
+                                        </button>
+                                    )}
                                 </div>
                             ))}
                         </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-import type { AnalysisRequest, AnalysisResponse, Announcement, AuthUser, AuthVerifyResponse, JobStatus, AnalysisReport, KlineResponse, LatestAnnouncementResponse, Report, ReportDetail, ReportListResponse, RuntimeConfig, RuntimeConfigUpdate, RuntimeConfigUpdateResponse, HotStock, UserToken, UserTokenCreateRequest } from '@/types'
+import type { AnalysisRequest, AnalysisResponse, Announcement, AuthUser, AuthVerifyResponse, JobStatus, AnalysisReport, KlineResponse, LatestAnnouncementResponse, Report, ReportDetail, ReportListResponse, RuntimeConfig, RuntimeConfigUpdate, RuntimeConfigUpdateResponse, WatchlistItem, ScheduledAnalysis, StockSearchResult, UserToken, UserTokenCreateRequest } from '@/types'
 
 export function getBaseUrl(): string {
     const envUrl = (import.meta.env.VITE_API_URL as string) || ''
@@ -130,8 +130,43 @@ class ApiService {
         })
     }
 
-    async getHotStocks(limit = 30, source = 'em'): Promise<{ stocks: HotStock[]; total: number }> {
-        return this.request<{ stocks: HotStock[]; total: number }>(`/v1/market/hot-stocks?limit=${limit}&source=${source}`)
+    // Watchlist
+    async getWatchlist(): Promise<{ items: WatchlistItem[] }> {
+        return this.request<{ items: WatchlistItem[] }>('/v1/watchlist')
+    }
+    async addToWatchlist(symbol: string): Promise<WatchlistItem> {
+        return this.request<WatchlistItem>('/v1/watchlist', {
+            method: 'POST',
+            body: JSON.stringify({ symbol }),
+        })
+    }
+    async removeFromWatchlist(id: string): Promise<void> {
+        await this.request('/v1/watchlist/' + id, { method: 'DELETE' })
+    }
+
+    // Scheduled Analysis
+    async getScheduled(): Promise<{ items: ScheduledAnalysis[] }> {
+        return this.request<{ items: ScheduledAnalysis[] }>('/v1/scheduled')
+    }
+    async createScheduled(symbol: string, horizon?: string, trigger_time?: string): Promise<ScheduledAnalysis> {
+        return this.request<ScheduledAnalysis>('/v1/scheduled', {
+            method: 'POST',
+            body: JSON.stringify({ symbol, horizon, trigger_time }),
+        })
+    }
+    async updateScheduled(id: string, data: { is_active?: boolean; horizon?: string; trigger_time?: string }): Promise<ScheduledAnalysis> {
+        return this.request<ScheduledAnalysis>('/v1/scheduled/' + id, {
+            method: 'PATCH',
+            body: JSON.stringify(data),
+        })
+    }
+    async deleteScheduled(id: string): Promise<void> {
+        await this.request('/v1/scheduled/' + id, { method: 'DELETE' })
+    }
+
+    // Stock Search
+    async searchStocks(q: string): Promise<{ results: StockSearchResult[] }> {
+        return this.request<{ results: StockSearchResult[] }>(`/v1/market/stock-search?q=${encodeURIComponent(q)}`)
     }
 
     async getConfig(): Promise<RuntimeConfig> {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -367,15 +367,33 @@ export interface LatestAnnouncementResponse {
     announcement: Announcement | null
 }
 
-// Hot stock from market hot rank
-export interface HotStock {
-    rank: number
+// Watchlist & Scheduled Analysis
+export interface WatchlistItem {
+    id: string
     symbol: string
     name: string
-    price: number
-    change: number
-    change_pct: number
-    extra: string  // Additional info like "连涨11天" or "关注 3,551,238"
+    sort_order: number
+    created_at: string
+    has_scheduled: boolean
+}
+
+export interface ScheduledAnalysis {
+    id: string
+    symbol: string
+    name: string
+    horizon: string
+    trigger_time: string
+    is_active: boolean
+    last_run_date: string | null
+    last_run_status: string | null
+    last_report_id: string | null
+    consecutive_failures: number
+    created_at: string
+}
+
+export interface StockSearchResult {
+    symbol: string
+    name: string
 }
 
 // Runtime config

--- a/tests/test_watchlist_scheduled.py
+++ b/tests/test_watchlist_scheduled.py
@@ -1,0 +1,161 @@
+"""Test watchlist and scheduled analysis services."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.database import Base
+from api.services import watchlist_service, scheduled_service
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+class TestWatchlist:
+    def test_add_and_list(self, db):
+        watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
+        items = watchlist_service.list_watchlist(db, "user1")
+        assert len(items) == 1
+        assert items[0]["symbol"] == "300750.SZ"
+
+    def test_duplicate_rejected(self, db):
+        watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
+        with pytest.raises(ValueError, match="已在自选列表中"):
+            watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
+
+    def test_max_limit(self, db):
+        for i in range(50):
+            watchlist_service.add_watchlist_item(db, "user1", f"{600000 + i}.SH")
+        with pytest.raises(ValueError, match="上限"):
+            watchlist_service.add_watchlist_item(db, "user1", "000001.SZ")
+
+    def test_delete(self, db):
+        item = watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
+        assert watchlist_service.delete_watchlist_item(db, "user1", item["id"])
+        assert len(watchlist_service.list_watchlist(db, "user1")) == 0
+
+    def test_user_isolation(self, db):
+        watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
+        watchlist_service.add_watchlist_item(db, "user2", "600519.SH")
+        assert len(watchlist_service.list_watchlist(db, "user1")) == 1
+        assert len(watchlist_service.list_watchlist(db, "user2")) == 1
+
+    def test_has_scheduled_flag(self, db):
+        watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
+        watchlist_service.add_watchlist_item(db, "user1", "600519.SH")
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        items = watchlist_service.list_watchlist(db, "user1")
+        by_symbol = {i["symbol"]: i for i in items}
+        assert by_symbol["300750.SZ"]["has_scheduled"] is True
+        assert by_symbol["600519.SH"]["has_scheduled"] is False
+
+
+class TestScheduled:
+    def test_create_and_list(self, db):
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short")
+        items = scheduled_service.list_scheduled(db, "user1")
+        assert len(items) == 1
+        assert items[0]["horizon"] == "short"
+        assert items[0]["trigger_time"] == "20:00"
+
+    def test_create_with_custom_time(self, db):
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "medium", "07:30")
+        items = scheduled_service.list_scheduled(db, "user1")
+        assert items[0]["trigger_time"] == "07:30"
+        assert items[0]["horizon"] == "medium"
+
+    def test_reject_daytime_hours(self, db):
+        with pytest.raises(ValueError, match="20:00"):
+            scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "10:30")
+        with pytest.raises(ValueError, match="20:00"):
+            scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "15:00")
+
+    def test_allow_boundary_times(self, db):
+        # 08:00 is the boundary, should be OK
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "08:00")
+        # 20:00 is the start, should be OK
+        scheduled_service.create_scheduled(db, "user1", "600519.SH", "short", "20:00")
+        # Midnight should be OK
+        scheduled_service.create_scheduled(db, "user1", "000001.SZ", "short", "00:30")
+
+    def test_duplicate_rejected(self, db):
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        with pytest.raises(ValueError, match="已有定时分析"):
+            scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+
+    def test_invalid_horizon(self, db):
+        with pytest.raises(ValueError, match="horizon"):
+            scheduled_service.create_scheduled(db, "user1", "300750.SZ", "long")
+
+    def test_max_limit(self, db):
+        for i in range(10):
+            scheduled_service.create_scheduled(db, "user1", f"{600000 + i}.SH")
+        with pytest.raises(ValueError, match="上限"):
+            scheduled_service.create_scheduled(db, "user1", "000001.SZ")
+
+    def test_update_horizon(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short")
+        updated = scheduled_service.update_scheduled(db, "user1", item["id"], horizon="medium")
+        assert updated["horizon"] == "medium"
+
+    def test_update_trigger_time(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        updated = scheduled_service.update_scheduled(db, "user1", item["id"], trigger_time="21:30")
+        assert updated["trigger_time"] == "21:30"
+
+    def test_update_reject_daytime(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        with pytest.raises(ValueError, match="20:00"):
+            scheduled_service.update_scheduled(db, "user1", item["id"], trigger_time="11:00")
+
+    def test_mark_success(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        scheduled_service.mark_run_success(db, item["id"], "2026-03-21", "report-123")
+        items = scheduled_service.list_scheduled(db, "user1")
+        assert items[0]["last_run_status"] == "success"
+        assert items[0]["last_report_id"] == "report-123"
+
+    def test_mark_failed_auto_deactivate(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        for day in range(1, 4):
+            scheduled_service.mark_run_failed(db, item["id"], f"2026-03-{20 + day}")
+        items = scheduled_service.list_scheduled(db, "user1")
+        assert items[0]["is_active"] is False
+        assert items[0]["consecutive_failures"] == 3
+
+    def test_reactivate_resets_failures(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        scheduled_service.mark_run_failed(db, item["id"], "2026-03-21")
+        scheduled_service.update_scheduled(db, "user1", item["id"], is_active=True)
+        items = scheduled_service.list_scheduled(db, "user1")
+        assert items[0]["consecutive_failures"] == 0
+
+    def test_get_pending_tasks_respects_trigger_time(self, db):
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "20:00")
+        scheduled_service.create_scheduled(db, "user1", "600519.SH", "short", "22:00")
+        # At 20:30, only the 20:00 task should be pending
+        tasks = scheduled_service.get_pending_tasks(db, "2026-03-21", "20:30")
+        assert len(tasks) == 1
+        assert tasks[0].symbol == "300750.SZ"
+        # At 22:00, both should be pending
+        tasks2 = scheduled_service.get_pending_tasks(db, "2026-03-21", "22:00")
+        assert len(tasks2) == 2
+
+    def test_get_pending_skips_already_run(self, db):
+        scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        tasks = scheduled_service.get_pending_tasks(db, "2026-03-21", "23:59")
+        scheduled_service.mark_run_success(db, tasks[0].id, "2026-03-21", "r1")
+        tasks2 = scheduled_service.get_pending_tasks(db, "2026-03-21", "23:59")
+        assert len(tasks2) == 0
+
+    def test_delete(self, db):
+        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        assert scheduled_service.delete_scheduled(db, "user1", item["id"])
+        assert len(scheduled_service.list_scheduled(db, "user1")) == 0

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import time
 from json import JSONDecodeError
 from typing import Any, Optional
 
 from langchain_openai import ChatOpenAI
+
+_logger = logging.getLogger(__name__)
 
 from .base_client import BaseLLMClient
 from .validators import validate_model
@@ -16,15 +19,19 @@ class UnifiedChatOpenAI(ChatOpenAI):
         # 彻底移除重试参数，由构造函数统一控制
         kwargs.pop("response_parse_retries", None)
         kwargs.pop("response_parse_retry_delay", None)
-        
+
         model = kwargs.get("model") or kwargs.get("model_name", "")
         base_url = kwargs.get("base_url")
-        
+
+        # LOG_LEVEL=DEBUG 时开启 LangChain verbose，打印完整的 LLM 请求和响应
+        if os.environ.get("LOG_LEVEL", "").upper() == "DEBUG":
+            kwargs["verbose"] = True
+
         # 1. Reasoning models (O1 etc) typically don't support temperature
         if self._is_reasoning_model(model):
             kwargs.pop("temperature", None)
             kwargs.pop("top_p", None)
-            
+
         # 2. Moonshot (Kimi) models often strictly require temperature=1
         if self._is_moonshot_model(model, base_url):
             kwargs["temperature"] = 1
@@ -32,7 +39,11 @@ class UnifiedChatOpenAI(ChatOpenAI):
         super().__init__(**kwargs)
 
     def invoke(self, input: Any, config: Any = None, **kwargs: Any) -> Any:
-        return super().invoke(input=input, config=config, **kwargs)
+        result = super().invoke(input=input, config=config, **kwargs)
+        if _logger.isEnabledFor(logging.DEBUG):
+            content = result.content if hasattr(result, "content") else str(result)
+            _logger.debug(f"[LLM Response] model={self.model_name} length={len(content)}\n{content}")
+        return result
 
     @staticmethod
     def _is_reasoning_model(model: str) -> bool:


### PR DESCRIPTION
## Summary

- **自选股管理**：数据库持久化的自选列表（上限 50），支持代码/名称模糊搜索添加
- **定时分析**：每个交易日 15:30 自动触发分析（上限 10 个任务），连续失败 3 次自动停用
- **调度器**：FastAPI lifespan 内嵌 asyncio 后台协程，幂等触发，非交易日自动跳过
- **前端改造**：Portfolio 页面从"热榜选股"重构为"自选 & 定时"，去掉外部热榜数据依赖
- **SQLite WAL**：启用 WAL 模式支持并发读写

## 新增 API

| 方法 | 路径 | 说明 |
|------|------|------|
| GET | `/v1/market/stock-search?q=` | 股票搜索（代码/名称模糊匹配） |
| GET/POST/DELETE | `/v1/watchlist` | 自选股增删查 |
| GET/POST/PATCH/DELETE | `/v1/scheduled` | 定时分析任务管理 |

## Test plan

- [x] 15 个 service 单元测试通过
- [x] 前端搜索添加自选股
- [x] 开启/关闭定时分析
- [x] 切换 horizons（短线/中线）
- [x] 连续失败自动停用 + 手动重新启用
- [x] 非交易日调度器跳过验证