### PR TITLE
feat: 报告列表和详情页展示股票名称

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -221,8 +221,9 @@ async def _run_scheduled_job(task: dict, trade_date: str):
                     _email_user = user
                     _email_report = report
             if _email_user and _email_report:
+                _stock_name = _get_reverse_stock_map().get(symbol, "")
                 _log(f"[Scheduler] Sending email report for {symbol} to {_email_user.email}")
-                asyncio.create_task(send_report_email_with_retry(_email_user, _email_report))
+                asyncio.create_task(send_report_email_with_retry(_email_user, _email_report, _stock_name))
         except Exception as e:
             logger.warning(f"[Scheduler] Email send failed for {symbol}: {e}")
 
@@ -604,6 +605,7 @@ class ReportResponse(BaseModel):
     id: str
     user_id: Optional[str]
     symbol: str
+    name: Optional[str] = None
     trade_date: str
     status: Literal["pending", "running", "completed", "failed"] = "completed"
     error: Optional[str] = None
@@ -2919,6 +2921,9 @@ def list_reports(
         skip=skip,
         limit=limit,
     )
+    code_to_name = _get_reverse_stock_map()
+    for r in reports:
+        r.name = code_to_name.get(r.symbol, r.symbol)
     return {"total": total, "reports": reports}
 
 
@@ -2932,6 +2937,8 @@ def get_report_endpoint(
     report = report_service.get_report(db, report_id, user_id=current_user.id)
     if not report:
         raise HTTPException(status_code=404, detail="报告不存在")
+    code_to_name = _get_reverse_stock_map()
+    report.name = code_to_name.get(report.symbol, report.symbol)
     return report
 
 

--- a/api/services/email_report_service.py
+++ b/api/services/email_report_service.py
@@ -161,10 +161,11 @@ _AGENT_SECTIONS = [
 _GITHUB_URL = "https://github.com/KylinMountain/TradingAgents-AShare"
 
 
-def render_report_html(report: "ReportDB", frontend_url: str = "") -> str:
+def render_report_html(report: "ReportDB", frontend_url: str = "", stock_name: str = "") -> str:
     """Render a *ReportDB* instance as an HTML email string with inline CSS."""
 
     symbol = _escape(report.symbol or "")
+    name = _escape(stock_name) if stock_name and stock_name != report.symbol else ""
     trade_date = _escape(report.trade_date or "")
     decision = _escape(report.decision or "-")
     direction = report.direction or ""
@@ -194,7 +195,7 @@ def render_report_html(report: "ReportDB", frontend_url: str = "") -> str:
         '<tr><td style="background:#0f172a;padding:28px 32px;">'
         f'<table width="100%" cellpadding="0" cellspacing="0"><tr>'
         f'<td><p style="margin:0;font-size:22px;font-weight:700;color:#ffffff;letter-spacing:-0.3px;">TradingAgents 投研报告</p>'
-        f'<p style="margin:6px 0 0;font-size:14px;color:#94a3b8;">{symbol} &middot; {trade_date}</p></td>'
+        f'<p style="margin:6px 0 0;font-size:14px;color:#94a3b8;">{name + " " if name else ""}{symbol} &middot; {trade_date}</p></td>'
         f'<td align="right" valign="top">'
         f'<span style="display:inline-block;background:{direction_bg};color:{direction_color};font-size:15px;font-weight:700;padding:6px 16px;border-radius:20px;">{_escape(direction) or "-"}</span>'
         f'</td></tr></table>'
@@ -400,7 +401,7 @@ def render_report_html(report: "ReportDB", frontend_url: str = "") -> str:
 # SMTP sending
 # ---------------------------------------------------------------------------
 
-def send_report_email(user: "UserDB", report: "ReportDB") -> bool:
+def send_report_email(user: "UserDB", report: "ReportDB", stock_name: str = "") -> bool:
     """Send the rendered report email via SMTP.
 
     Returns True on success, False on failure.  Never raises.
@@ -422,21 +423,22 @@ def send_report_email(user: "UserDB", report: "ReportDB") -> bool:
     smtp_ssl_tls = smtp_ssl_tls_str in ("1", "true", "on", "yes")
 
     frontend_url = _infer_frontend_url()
-    html_body = render_report_html(report, frontend_url=frontend_url)
+    html_body = render_report_html(report, frontend_url=frontend_url, stock_name=stock_name)
     symbol = report.symbol or ""
     trade_date = report.trade_date or ""
+    display_name = f"{stock_name} {symbol}" if stock_name and stock_name != symbol else symbol
 
     report_link = ""
     if frontend_url:
         report_link = f"\n\n查看完整报告: {frontend_url.rstrip('/')}/reports?report={report.id}"
 
     msg = EmailMessage()
-    msg["Subject"] = f"TradingAgents 投研报告 - {symbol} ({trade_date})"
+    msg["Subject"] = f"TradingAgents 投研报告 - {display_name} ({trade_date})"
     msg["From"] = smtp_from
     msg["To"] = user.email
 
     # text/plain fallback
-    plain = f"TradingAgents 投研报告\n{symbol} {trade_date}\n决策: {report.decision or '-'}\n方向: {report.direction or '-'}\n置信度: {report.confidence or '-'}%{report_link}\n\n请使用支持 HTML 的邮件客户端查看完整报告。"
+    plain = f"TradingAgents 投研报告\n{display_name} {trade_date}\n决策: {report.decision or '-'}\n方向: {report.direction or '-'}\n置信度: {report.confidence or '-'}%{report_link}\n\n请使用支持 HTML 的邮件客户端查看完整报告。"
     msg.set_content(plain)
     msg.add_alternative(html_body, subtype="html")
 
@@ -460,16 +462,16 @@ def send_report_email(user: "UserDB", report: "ReportDB") -> bool:
 # Async wrapper with retry
 # ---------------------------------------------------------------------------
 
-async def send_report_email_with_retry(user: "UserDB", report: "ReportDB") -> bool:
+async def send_report_email_with_retry(user: "UserDB", report: "ReportDB", stock_name: str = "") -> bool:
     """Send report email asynchronously, retrying once on failure after 180 s."""
-    ok = await asyncio.to_thread(send_report_email, user, report)
+    ok = await asyncio.to_thread(send_report_email, user, report, stock_name)
     if ok:
         logger.info(f"[email_report] first attempt succeeded for {user.email}")
         return True
 
     logger.warning(f"[email_report] first attempt failed for {user.email}, retrying in 180s")
     await asyncio.sleep(180)
-    ok = await asyncio.to_thread(send_report_email, user, report)
+    ok = await asyncio.to_thread(send_report_email, user, report, stock_name)
     if ok:
         logger.info(f"[email_report] retry succeeded for {user.email}")
     else:

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -129,7 +129,7 @@ export default function Dashboard() {
                                             <FileText className="w-4 h-4 text-blue-600 dark:text-blue-400" />
                                         </div>
                                         <div>
-                                            <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">{report.symbol}</p>
+                                            <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">{report.name || report.symbol}</p>
                                             <p className="text-xs text-slate-400 dark:text-slate-500">{report.trade_date}</p>
                                         </div>
                                     </div>

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -169,9 +169,10 @@ export default function Reports() {
             .finally(() => setDetailLoading(false))
     }, [searchParams, selectedReport?.id])
 
-    const filteredReports = reports.filter(r =>
-        r.symbol.toLowerCase().includes(searchQuery.toLowerCase())
-    )
+    const filteredReports = reports.filter(r => {
+        const q = searchQuery.toLowerCase()
+        return r.symbol.toLowerCase().includes(q) || (r.name?.toLowerCase().includes(q) ?? false)
+    })
 
     // ─── 详情视图 ────────────────────────────────────────────────────────────
     if (detailLoading) {
@@ -201,7 +202,10 @@ export default function Reports() {
                         返回列表
                     </button>
                     <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
-                        {selectedReport.symbol} 分析报告
+                        {selectedReport.name || selectedReport.symbol} 分析报告
+                        {selectedReport.name && selectedReport.name !== selectedReport.symbol && (
+                            <span className="ml-2 text-base font-normal text-slate-400">{selectedReport.symbol}</span>
+                        )}
                     </h1>
                     <button
                         onClick={() => exportReport(selectedReport)}
@@ -223,7 +227,7 @@ export default function Reports() {
                     <div className="card">
                         <div className="flex items-center gap-2 mb-3">
                             <History className="w-4 h-4 text-slate-400" />
-                            <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{selectedReport.symbol} 历史决策</h3>
+                            <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{selectedReport.name || selectedReport.symbol} 历史决策</h3>
                         </div>
                         <div className="flex items-center gap-2 overflow-x-auto pb-1">
                             {symbolHistory.slice().reverse().map(r => {
@@ -251,6 +255,7 @@ export default function Reports() {
                     {selectedReport.status === 'completed' ? (
                         <DecisionCard
                             symbol={selectedReport.symbol}
+                            name={selectedReport.name}
                             decision={action}
                             direction={selectedReport.direction}
                             confidence={selectedReport.confidence ?? undefined}
@@ -302,7 +307,7 @@ export default function Reports() {
                         type="text"
                         value={searchQuery}
                         onChange={e => setSearchQuery(e.target.value)}
-                        placeholder="搜索股票代码..."
+                        placeholder="搜索股票代码或名称..."
                         className="input w-full pl-10"
                     />
                 </div>
@@ -338,7 +343,7 @@ export default function Reports() {
                         <table className="w-full">
                             <thead>
                                 <tr className="border-b border-slate-200 dark:border-slate-700">
-                                    {['股票代码', '分析日期', '决策建议', '置信度', '目标价/止损价', '生成时间', '操作'].map(h => (
+                                    {['股票', '分析日期', '决策建议', '置信度', '目标价/止损价', '生成时间', '操作'].map(h => (
                                         <th key={h} className={`py-3 px-4 text-sm font-medium text-slate-500 dark:text-slate-400 ${h === '操作' ? 'text-right' : 'text-left'}`}>
                                             {h}
                                         </th>
@@ -358,7 +363,12 @@ export default function Reports() {
                                                     <div className="w-8 h-8 rounded-lg bg-blue-100 dark:bg-blue-500/10 flex items-center justify-center">
                                                         <FileText className="w-4 h-4 text-blue-600 dark:text-blue-400" />
                                                     </div>
-                                                    <p className="font-medium text-slate-900 dark:text-slate-100">{report.symbol}</p>
+                                                    <div>
+                                                        <p className="font-medium text-slate-900 dark:text-slate-100">{report.name || report.symbol}</p>
+                                                        {report.name && report.name !== report.symbol && (
+                                                            <p className="text-xs text-slate-400 dark:text-slate-500">{report.symbol}</p>
+                                                        )}
+                                                    </div>
                                                 </div>
                                             </td>
                                             <td className="py-3 px-4 text-slate-600 dark:text-slate-400">{report.trade_date}</td>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -316,6 +316,7 @@ export interface Report {
     id: string
     user_id?: string
     symbol: string
+    name?: string
     trade_date: string
     status: 'pending' | 'running' | 'completed' | 'failed'
     error?: string


### PR DESCRIPTION
## Summary

- 报告列表和详情页展示股票名称（如「拓维信息」），代码作为副行显示
- 搜索支持按名称或代码查找
- DecisionCard 组件传入股票名称
- 邮件报告标题和正文同步显示股票名称

Closes #80

## Changes

- **`api/main.py`**: `ReportResponse` 新增 `name` 字段，报告列表和详情接口用 `_get_reverse_stock_map()` 填充名称；邮件发送传入 stock_name
- **`api/services/email_report_service.py`**: `render_report_html` / `send_report_email` / `send_report_email_with_retry` 支持 `stock_name` 参数
- **`frontend/src/types/index.ts`**: `Report` 接口新增 `name` 字段
- **`frontend/src/pages/Reports.tsx`**: 列表显示名称+代码，详情标题显示名称，搜索支持名称

## Test plan

- [x] 19 个后端测试通过
- [x] TypeScript 编译通过
- [x] 后端 app 加载正常
- [ ] 手动验证报告列表和详情页显示股票名称
- [ ] 手动验证邮件标题包含股票名称

🤖 Generated with [Claude Code](https://claude.com/claude-code)