### PR TITLE
feat: React Flow 重构 Agent 协同工作流为水平流程图

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.1.0",
+        "@xyflow/react": "^12.10.2",
         "clsx": "^2.1.0",
         "date-fns": "^3.3.1",
         "lightweight-charts": "^5.1.0",
@@ -1526,6 +1527,15 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
@@ -1556,6 +1566,12 @@
         "@types/d3-time": "*"
       }
     },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-shape": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
@@ -1576,6 +1592,25 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -1935,6 +1970,38 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -2337,6 +2404,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2455,6 +2528,28 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -2510,6 +2605,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-shape": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
@@ -2551,6 +2655,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.1.0",
+    "@xyflow/react": "^12.10.2",
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",
     "lightweight-charts": "^5.1.0",

--- a/frontend/src/components/AgentCollaboration.tsx
+++ b/frontend/src/components/AgentCollaboration.tsx
@@ -1,4 +1,14 @@
-import { useMemo } from 'react'
+import { useMemo, useCallback, memo } from 'react'
+import {
+    ReactFlow,
+    Handle,
+    Position,
+    MarkerType,
+    type Node,
+    type Edge,
+    type NodeProps,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
 import { useAnalysisStore } from '@/stores/analysisStore'
 import type { AgentStatus } from '@/types'
 import {
@@ -8,7 +18,7 @@ import {
 } from 'lucide-react'
 import { extractVerdict, type Verdict } from '@/utils/reportText'
 
-// ── Agent 元数据 (保持原有色彩与中文) ──────────────────────────────────────────
+// ── Agent 元数据 ──────────────────────────────────────────────────────────────
 
 interface AgentMeta {
     name: string
@@ -19,126 +29,24 @@ interface AgentMeta {
     Icon: React.FC<{ className?: string }>
     badgeBg: string
     badgeText: string
-    sumBorder: string
-    sumBg: string
-    sumText: string
-    activePill: string
 }
 
 const META: AgentMeta[] = [
-    {
-        name: 'Market Analyst', label: '技术面', goal: '技术指标与价格形态分析',
-        section: 'market_report', Icon: TrendingUp,
-        badgeBg: 'bg-blue-100 dark:bg-blue-500/20', badgeText: 'text-blue-600 dark:text-blue-400',
-        sumBorder: 'border-blue-200 dark:border-blue-500/40', sumBg: 'bg-blue-50 dark:bg-blue-500/5', sumText: 'text-blue-700 dark:text-blue-300',
-        activePill: 'bg-blue-500 text-white',
-    },
-    {
-        name: 'Social Analyst', label: '舆情', goal: '舆论情绪与社交媒体分析',
-        section: 'sentiment_report', Icon: MessageCircle,
-        badgeBg: 'bg-fuchsia-100 dark:bg-fuchsia-500/20', badgeText: 'text-fuchsia-600 dark:text-fuchsia-400',
-        sumBorder: 'border-fuchsia-200 dark:border-fuchsia-500/40', sumBg: 'bg-fuchsia-50 dark:bg-fuchsia-500/5', sumText: 'text-fuchsia-700 dark:text-fuchsia-300',
-        activePill: 'bg-fuchsia-500 text-white',
-    },
-    {
-        name: 'News Analyst', label: '新闻', goal: '政策资讯与行业动态分析',
-        section: 'news_report', Icon: Newspaper,
-        badgeBg: 'bg-cyan-100 dark:bg-cyan-500/20', badgeText: 'text-cyan-600 dark:text-cyan-400',
-        sumBorder: 'border-cyan-200 dark:border-cyan-500/40', sumBg: 'bg-cyan-50 dark:bg-cyan-500/5', sumText: 'text-cyan-700 dark:text-cyan-300',
-        activePill: 'bg-cyan-500 text-white',
-    },
-    {
-        name: 'Fundamentals Analyst', label: '基本面', goal: '财务报表与估值分析',
-        section: 'fundamentals_report', Icon: Calculator,
-        badgeBg: 'bg-emerald-100 dark:bg-emerald-500/20', badgeText: 'text-emerald-600 dark:text-emerald-400',
-        sumBorder: 'border-emerald-200 dark:border-emerald-500/40', sumBg: 'bg-emerald-50 dark:bg-emerald-500/5', sumText: 'text-emerald-700 dark:text-emerald-300',
-        activePill: 'bg-emerald-500 text-white',
-    },
-    {
-        name: 'Macro Analyst', label: '宏观', goal: '板块轮动与政策驱动分析',
-        section: 'macro_report', Icon: BarChart2,
-        badgeBg: 'bg-violet-100 dark:bg-violet-500/20', badgeText: 'text-violet-600 dark:text-violet-400',
-        sumBorder: 'border-violet-200 dark:border-violet-500/40', sumBg: 'bg-violet-50 dark:bg-violet-500/5', sumText: 'text-violet-700 dark:text-violet-300',
-        activePill: 'bg-violet-500 text-white',
-    },
-    {
-        name: 'Smart Money Analyst', label: '主力资金', goal: '机构资金行为与龙虎榜',
-        section: 'smart_money_report', Icon: DollarSign,
-        badgeBg: 'bg-amber-100 dark:bg-amber-500/20', badgeText: 'text-amber-600 dark:text-amber-400',
-        sumBorder: 'border-amber-200 dark:border-amber-500/40', sumBg: 'bg-amber-50 dark:bg-amber-500/5', sumText: 'text-amber-700 dark:text-amber-300',
-        activePill: 'bg-amber-500 text-white',
-    },
-    {
-        name: 'Game Theory Manager', label: '博弈裁判', goal: '主力与散户预期差裁判',
-        section: 'game_theory_report', Icon: Swords,
-        badgeBg: 'bg-rose-100 dark:bg-rose-500/20', badgeText: 'text-rose-600 dark:text-rose-400',
-        sumBorder: 'border-rose-200 dark:border-rose-500/40', sumBg: 'bg-rose-50 dark:bg-rose-500/5', sumText: 'text-rose-700 dark:text-rose-300',
-        activePill: 'bg-rose-500 text-white',
-    },
-    {
-        name: 'Bull Researcher', label: '多头', goal: '评估投资价值与上行潜力',
-        section: 'investment_plan', debate: 'research', Icon: ArrowBigUp,
-        badgeBg: 'bg-emerald-100 dark:bg-emerald-500/20', badgeText: 'text-emerald-600 dark:text-emerald-400',
-        sumBorder: 'border-emerald-200 dark:border-emerald-500/40', sumBg: 'bg-emerald-50 dark:bg-emerald-500/5', sumText: 'text-emerald-700 dark:text-emerald-300',
-        activePill: 'bg-emerald-500 text-white',
-    },
-    {
-        name: 'Bear Researcher', label: '空头', goal: '评估下行风险与潜在危机',
-        section: 'investment_plan', debate: 'research', Icon: ArrowBigDown,
-        badgeBg: 'bg-rose-100 dark:bg-rose-500/20', badgeText: 'text-rose-600 dark:text-rose-400',
-        sumBorder: 'border-rose-200 dark:border-rose-500/40', sumBg: 'bg-rose-50 dark:bg-rose-500/5', sumText: 'text-rose-700 dark:text-rose-300',
-        activePill: 'bg-rose-500 text-white',
-    },
-    {
-        name: 'Research Manager', label: '研究总监', goal: '综合多空论据形成投资计划',
-        section: 'investment_plan', debate: 'research', Icon: Brain,
-        badgeBg: 'bg-indigo-100 dark:bg-indigo-500/20', badgeText: 'text-indigo-600 dark:text-indigo-400',
-        sumBorder: 'border-indigo-200 dark:border-indigo-500/40', sumBg: 'bg-indigo-50 dark:bg-indigo-500/5', sumText: 'text-indigo-700 dark:text-indigo-300',
-        activePill: 'bg-indigo-500 text-white',
-    },
-    {
-        name: 'Trader', label: '交易员', goal: '将研究结论转化为可执行指令',
-        section: 'trader_investment_plan', Icon: Briefcase,
-        badgeBg: 'bg-orange-100 dark:bg-orange-500/20', badgeText: 'text-orange-600 dark:text-orange-400',
-        sumBorder: 'border-orange-200 dark:border-orange-500/40', sumBg: 'bg-orange-50 dark:bg-orange-500/5', sumText: 'text-orange-700 dark:text-orange-300',
-        activePill: 'bg-orange-500 text-white',
-    },
-    {
-        name: 'Aggressive Analyst', label: '激进', goal: '高风险高收益策略约束',
-        section: 'final_trade_decision', debate: 'risk', Icon: Flame,
-        badgeBg: 'bg-red-100 dark:bg-red-500/20', badgeText: 'text-red-600 dark:text-red-400',
-        sumBorder: 'border-red-200 dark:border-red-500/40', sumBg: 'bg-red-50 dark:bg-red-500/5', sumText: 'text-red-700 dark:text-red-300',
-        activePill: 'bg-red-500 text-white',
-    },
-    {
-        name: 'Neutral Analyst', label: '中性', goal: '均衡风险收益策略约束',
-        section: 'final_trade_decision', debate: 'risk', Icon: Scale,
-        badgeBg: 'bg-slate-100 dark:bg-slate-500/20', badgeText: 'text-slate-600 dark:text-slate-400',
-        sumBorder: 'border-slate-200 dark:border-slate-500/40', sumBg: 'bg-slate-50 dark:bg-slate-500/5', sumText: 'text-slate-600 dark:text-slate-300',
-        activePill: 'bg-slate-600 text-white',
-    },
-    {
-        name: 'Conservative Analyst', label: '稳健', goal: '低风险保守策略约束',
-        section: 'final_trade_decision', debate: 'risk', Icon: Shield,
-        badgeBg: 'bg-amber-100 dark:bg-amber-500/20', badgeText: 'text-amber-600 dark:text-amber-400',
-        sumBorder: 'border-amber-200 dark:border-amber-500/40', sumBg: 'bg-amber-50 dark:bg-amber-500/5', sumText: 'text-amber-700 dark:text-amber-300',
-        activePill: 'bg-amber-500 text-white',
-    },
-    {
-        name: 'Portfolio Manager', label: '组合经理', goal: '综合裁决形成最终决策',
-        section: 'final_trade_decision', debate: 'risk', Icon: CheckCircle2,
-        badgeBg: 'bg-teal-100 dark:bg-teal-500/20', badgeText: 'text-teal-600 dark:text-teal-400',
-        sumBorder: 'border-teal-200 dark:border-teal-500/40', sumBg: 'bg-teal-50 dark:bg-teal-500/5', sumText: 'text-teal-700 dark:text-teal-300',
-        activePill: 'bg-teal-500 text-white',
-    },
-]
-
-const GROUPS = [
-    { title: '分析团队', cols: 'grid-cols-3', agents: ['Market Analyst','Social Analyst','News Analyst','Fundamentals Analyst','Macro Analyst','Smart Money Analyst'] },
-    { title: '博弈裁判', cols: 'grid-cols-1', agents: ['Game Theory Manager'] },
-    { title: '多空辩论', cols: 'grid-cols-3', agents: ['Bull Researcher','Bear Researcher','Research Manager'] },
-    { title: '交易执行', cols: 'grid-cols-1', agents: ['Trader'] },
-    { title: '风控裁决', cols: 'grid-cols-4', agents: ['Aggressive Analyst','Neutral Analyst','Conservative Analyst','Portfolio Manager'] },
+    { name: 'Market Analyst', label: '技术面', goal: '技术指标与价格形态分析', section: 'market_report', Icon: TrendingUp, badgeBg: 'bg-blue-100 dark:bg-blue-500/20', badgeText: 'text-blue-600 dark:text-blue-400' },
+    { name: 'Social Analyst', label: '舆情', goal: '舆论情绪与社交媒体分析', section: 'sentiment_report', Icon: MessageCircle, badgeBg: 'bg-fuchsia-100 dark:bg-fuchsia-500/20', badgeText: 'text-fuchsia-600 dark:text-fuchsia-400' },
+    { name: 'News Analyst', label: '新闻', goal: '政策资讯与行业动态分析', section: 'news_report', Icon: Newspaper, badgeBg: 'bg-cyan-100 dark:bg-cyan-500/20', badgeText: 'text-cyan-600 dark:text-cyan-400' },
+    { name: 'Fundamentals Analyst', label: '基本面', goal: '财务报表与估值分析', section: 'fundamentals_report', Icon: Calculator, badgeBg: 'bg-emerald-100 dark:bg-emerald-500/20', badgeText: 'text-emerald-600 dark:text-emerald-400' },
+    { name: 'Macro Analyst', label: '宏观', goal: '板块轮动与政策驱动分析', section: 'macro_report', Icon: BarChart2, badgeBg: 'bg-violet-100 dark:bg-violet-500/20', badgeText: 'text-violet-600 dark:text-violet-400' },
+    { name: 'Smart Money Analyst', label: '主力资金', goal: '机构资金行为与龙虎榜', section: 'smart_money_report', Icon: DollarSign, badgeBg: 'bg-amber-100 dark:bg-amber-500/20', badgeText: 'text-amber-600 dark:text-amber-400' },
+    { name: 'Game Theory Manager', label: '博弈裁判', goal: '主力与散户预期差裁判', section: 'game_theory_report', Icon: Swords, badgeBg: 'bg-rose-100 dark:bg-rose-500/20', badgeText: 'text-rose-600 dark:text-rose-400' },
+    { name: 'Bull Researcher', label: '多头', goal: '评估投资价值与上行潜力', section: 'investment_plan', debate: 'research', Icon: ArrowBigUp, badgeBg: 'bg-emerald-100 dark:bg-emerald-500/20', badgeText: 'text-emerald-600 dark:text-emerald-400' },
+    { name: 'Bear Researcher', label: '空头', goal: '评估下行风险与潜在危机', section: 'investment_plan', debate: 'research', Icon: ArrowBigDown, badgeBg: 'bg-rose-100 dark:bg-rose-500/20', badgeText: 'text-rose-600 dark:text-rose-400' },
+    { name: 'Research Manager', label: '研究总监', goal: '综合多空论据形成投资计划', section: 'investment_plan', debate: 'research', Icon: Brain, badgeBg: 'bg-indigo-100 dark:bg-indigo-500/20', badgeText: 'text-indigo-600 dark:text-indigo-400' },
+    { name: 'Trader', label: '交易员', goal: '将研究结论转化为可执行指令', section: 'trader_investment_plan', Icon: Briefcase, badgeBg: 'bg-orange-100 dark:bg-orange-500/20', badgeText: 'text-orange-600 dark:text-orange-400' },
+    { name: 'Aggressive Analyst', label: '激进', goal: '高风险高收益策略约束', section: 'final_trade_decision', debate: 'risk', Icon: Flame, badgeBg: 'bg-red-100 dark:bg-red-500/20', badgeText: 'text-red-600 dark:text-red-400' },
+    { name: 'Neutral Analyst', label: '中性', goal: '均衡风险收益策略约束', section: 'final_trade_decision', debate: 'risk', Icon: Scale, badgeBg: 'bg-slate-100 dark:bg-slate-500/20', badgeText: 'text-slate-600 dark:text-slate-400' },
+    { name: 'Conservative Analyst', label: '稳健', goal: '低风险保守策略约束', section: 'final_trade_decision', debate: 'risk', Icon: Shield, badgeBg: 'bg-amber-100 dark:bg-amber-500/20', badgeText: 'text-amber-600 dark:text-amber-400' },
+    { name: 'Portfolio Manager', label: '组合经理', goal: '综合裁决形成最终决策', section: 'final_trade_decision', debate: 'risk', Icon: CheckCircle2, badgeBg: 'bg-teal-100 dark:bg-teal-500/20', badgeText: 'text-teal-600 dark:text-teal-400' },
 ]
 
 const STATUS_LABEL: Record<AgentStatus, string> = {
@@ -153,100 +61,209 @@ const VERDICT_COLORS: Record<string, string> = {
     _default: 'bg-slate-100 text-slate-500 dark:bg-slate-700/50 dark:text-slate-400',
 }
 
-// ── 子组件：Agent 卡片 (恢复原始比例与高对比度) ──────────────────────────────────
+// ── 流程图布局 ────────────────────────────────────────────────────────────────
 
-interface CardData extends AgentMeta { 
-    status: AgentStatus; 
-    isStreaming: boolean; 
-    verdict: Verdict | null;
-    isParticipating: boolean; 
+const NODE_POSITIONS: Record<string, { x: number; y: number }> = {
+    // 左列：数据源分析师（紧凑排列）
+    'Market Analyst':       { x: 0, y: 0 },
+    'Social Analyst':       { x: 0, y: 105 },
+    'News Analyst':         { x: 0, y: 210 },
+    'Fundamentals Analyst': { x: 0, y: 315 },
+    'Macro Analyst':        { x: 0, y: 420 },
+    'Smart Money Analyst':  { x: 0, y: 525 },
+    // 博弈裁判
+    'Game Theory Manager':  { x: 310, y: 240 },
+    // 研究团队
+    'Bull Researcher':      { x: 600, y: 80 },
+    'Research Manager':     { x: 600, y: 240 },
+    'Bear Researcher':      { x: 600, y: 400 },
+    // 交易员
+    'Trader':               { x: 890, y: 240 },
+    // 风控团队
+    'Aggressive Analyst':   { x: 1180, y: 80 },
+    'Neutral Analyst':      { x: 1180, y: 240 },
+    'Conservative Analyst': { x: 1180, y: 400 },
+    // 组合经理
+    'Portfolio Manager':    { x: 1470, y: 240 },
 }
 
-function AgentCard({ card, selected, onClick }: { card: CardData; selected?: boolean; onClick?: () => void }) {
-    const active  = card.status === 'in_progress'
-    const done    = card.status === 'completed'
-    const skipped = card.status === 'skipped'
-    const participating = card.isParticipating
-    const clickable = (!!card.section || !!card.debate) && (done || active)
-    const { Icon } = card
+// 需要额外 handle 的节点（用于辩论连线）
+const BOTTOM_HANDLE_NODES = new Set(['Bull Researcher'])
+const TOP_HANDLE_NODES = new Set(['Bear Researcher'])
+
+// 边定义
+interface EdgeDef {
+    source: string
+    target: string
+    sourceHandle?: string
+    targetHandle?: string
+    label?: string
+    bidirectional?: boolean
+    thin?: boolean
+}
+
+const EDGE_DEFS: EdgeDef[] = [
+    // 数据源 → 博弈裁判
+    ...['Market Analyst', 'Social Analyst', 'News Analyst', 'Fundamentals Analyst', 'Macro Analyst', 'Smart Money Analyst']
+        .map(s => ({ source: s, target: 'Game Theory Manager', thin: true } as EdgeDef)),
+    // 博弈裁判 → 多空研究员
+    { source: 'Game Theory Manager', target: 'Bull Researcher' },
+    { source: 'Game Theory Manager', target: 'Bear Researcher' },
+    // 多空辩论（双向）
+    { source: 'Bull Researcher', target: 'Bear Researcher', sourceHandle: 'bottom', targetHandle: 'top', label: '辩论', bidirectional: true },
+    // 研究员 → 研究总监
+    { source: 'Bull Researcher', target: 'Research Manager' },
+    { source: 'Bear Researcher', target: 'Research Manager' },
+    // 研究总监 → 交易员
+    { source: 'Research Manager', target: 'Trader', label: '投资计划' },
+    // 交易员 → 风控
+    { source: 'Trader', target: 'Aggressive Analyst' },
+    { source: 'Trader', target: 'Neutral Analyst', label: '交易方案' },
+    { source: 'Trader', target: 'Conservative Analyst' },
+    // 风控 → 组合经理
+    { source: 'Aggressive Analyst', target: 'Portfolio Manager' },
+    { source: 'Neutral Analyst', target: 'Portfolio Manager' },
+    { source: 'Conservative Analyst', target: 'Portfolio Manager' },
+]
+
+// ── 分组标签节点 ──────────────────────────────────────────────────────────────
+
+interface GroupLabelDef {
+    id: string
+    label: string
+    position: { x: number; y: number }
+    width: number
+    height: number
+}
+
+const GROUP_LABELS: GroupLabelDef[] = [
+    { id: 'group-sources', label: '数据分析', position: { x: -16, y: -30 }, width: 248, height: 640 },
+    { id: 'group-research', label: '研究团队', position: { x: 584, y: 44 }, width: 248, height: 450 },
+    { id: 'group-risk', label: '风控团队', position: { x: 1164, y: 44 }, width: 248, height: 450 },
+]
+
+// ── 自定义节点组件 ────────────────────────────────────────────────────────────
+
+interface AgentNodeData {
+    meta: AgentMeta
+    status: AgentStatus
+    verdict: Verdict | null
+    isParticipating: boolean
+    selected: boolean
+    [key: string]: unknown
+}
+
+function AgentNodeComponent({ data }: NodeProps<Node<AgentNodeData>>) {
+    const { meta, status, verdict, isParticipating, selected } = data
+    const active = status === 'in_progress'
+    const done = status === 'completed'
+    const skipped = status === 'skipped'
+    const { Icon } = meta
 
     return (
-        <button
-            type="button"
-            disabled={!clickable}
-            onClick={() => clickable && onClick?.()}
+        <div
             className={[
-                'group relative w-full text-left rounded-xl border transition-all duration-300 overflow-hidden',
-                !participating ? 'grayscale opacity-30 scale-95 border-slate-100 dark:border-slate-800' : 'opacity-100',
+                'px-4 py-3 rounded-xl border transition-all duration-300 min-w-[210px] max-w-[218px]',
+                !isParticipating ? 'opacity-30 grayscale' : '',
                 selected
                     ? 'border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-500/10 shadow-lg ring-2 ring-blue-400/30'
                     : active
-                    ? 'border-blue-400/60 dark:border-blue-500/60 bg-white dark:bg-slate-800 shadow-[0_0_12px_rgba(59,130,246,0.2)] z-10'
+                    ? 'border-blue-400 dark:border-blue-500/60 bg-white dark:bg-slate-800 shadow-[0_0_14px_rgba(59,130,246,0.25)]'
                     : done
-                    ? 'border-emerald-300 dark:border-emerald-500/50 bg-emerald-50/30 dark:bg-slate-800/60 shadow-sm'
+                    ? 'border-emerald-300 dark:border-emerald-500/50 bg-white dark:bg-slate-800/80 shadow-sm'
                     : skipped
-                    ? 'border-slate-100 dark:border-slate-800 bg-transparent opacity-40'
+                    ? 'border-slate-100 dark:border-slate-800 bg-white/50 dark:bg-slate-900/50 opacity-40'
                     : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-sm',
-                clickable ? 'cursor-pointer hover:border-slate-400 dark:hover:border-slate-500' : 'cursor-default',
             ].join(' ')}
         >
-            <div className="p-4 relative z-10">
-                <div className="flex items-start gap-3 mb-3">
-                    <div className={`shrink-0 w-10 h-10 rounded-xl flex items-center justify-center transition-all duration-500 ${active ? 'scale-110 shadow-blue-400/20' : ''} ${card.badgeBg}`}>
-                        {active
-                            ? <Loader2 className={`w-5 h-5 animate-spin ${card.badgeText}`} />
-                            : <Icon className={`w-5 h-5 ${card.badgeText}`} />
-                        }
-                    </div>
-                    <div className="min-w-0 flex-1 pt-0.5">
-                        <div className={`text-[14px] font-bold leading-tight transition-colors ${active ? 'text-blue-600 dark:text-blue-400' : 'text-slate-900 dark:text-slate-100'}`}>
-                            {card.label}
-                        </div>
-                        <div className="text-[11px] text-slate-500 dark:text-slate-400 leading-tight mt-1 line-clamp-1">
-                            {card.goal}
-                        </div>
-                    </div>
-                    <span className={[
-                        'shrink-0 mt-0.5 text-[10px] px-2 py-0.5 rounded-full font-bold transition-all duration-300 shadow-sm',
-                        active  ? 'bg-blue-600 text-white animate-pulse'
-                        : done  ? 'bg-emerald-500 text-white'
-                        : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400',
-                    ].join(' ')}>
-                        {STATUS_LABEL[card.status]}
+            {/* Handles */}
+            <Handle type="target" position={Position.Left} id="left"
+                className="!w-2 !h-2 !bg-slate-300 dark:!bg-slate-600 !border-0 !min-w-0 !min-h-0" />
+            <Handle type="source" position={Position.Right} id="right"
+                className="!w-2 !h-2 !bg-slate-300 dark:!bg-slate-600 !border-0 !min-w-0 !min-h-0" />
+
+            {BOTTOM_HANDLE_NODES.has(meta.name) && (
+                <Handle type="source" position={Position.Bottom} id="bottom"
+                    className="!w-2 !h-2 !bg-slate-300 dark:!bg-slate-600 !border-0 !min-w-0 !min-h-0" />
+            )}
+            {TOP_HANDLE_NODES.has(meta.name) && (
+                <Handle type="target" position={Position.Top} id="top"
+                    className="!w-2 !h-2 !bg-slate-300 dark:!bg-slate-600 !border-0 !min-w-0 !min-h-0" />
+            )}
+
+            {/* 第一行：图标 + 标签 + 状态 */}
+            <div className="flex items-center gap-2.5">
+                <div className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${meta.badgeBg}`}>
+                    {active
+                        ? <Loader2 className={`w-[18px] h-[18px] animate-spin ${meta.badgeText}`} />
+                        : <Icon className={`w-[18px] h-[18px] ${meta.badgeText}`} />}
+                </div>
+                <span className={`text-[15px] font-bold flex-1 leading-tight ${active ? 'text-blue-600 dark:text-blue-400' : 'text-slate-800 dark:text-slate-200'}`}>
+                    {meta.label}
+                </span>
+                <span className={[
+                    'shrink-0 text-[11px] px-2 py-0.5 rounded-full font-bold',
+                    active ? 'bg-blue-600 text-white animate-pulse'
+                        : done ? 'bg-emerald-500 text-white'
+                        : 'bg-slate-100 text-slate-400 dark:bg-slate-700 dark:text-slate-500',
+                ].join(' ')}>
+                    {STATUS_LABEL[status]}
+                </span>
+            </div>
+
+            {/* 第二行：分析中动画 */}
+            {active && (
+                <div className="flex items-center gap-2 mt-2">
+                    <span className="flex gap-1">
+                        <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:-0.3s]" />
+                        <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:-0.15s]" />
+                        <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce" />
+                    </span>
+                    <span className="text-[12px] text-blue-600 dark:text-blue-400 font-bold">研判中...</span>
+                </div>
+            )}
+
+            {/* 第二行：完成后的判定结果 */}
+            {done && verdict && (
+                <div className="flex items-center gap-2 mt-2 min-w-0">
+                    <span className={`shrink-0 text-[11px] font-black px-2 py-0.5 rounded-full leading-none ${VERDICT_COLORS[verdict.direction] ?? VERDICT_COLORS._default}`}>
+                        {verdict.direction}
+                    </span>
+                    <span className="text-[12px] text-slate-500 dark:text-slate-400 leading-tight line-clamp-1">
+                        {verdict.reason}
                     </span>
                 </div>
+            )}
 
-                {(done || active) && (
-                    <div className={`rounded-lg border px-3 py-2.5 transition-all duration-500 ${card.sumBorder} ${card.sumBg}`}>
-                        {active ? (
-                            <div className="flex items-center gap-2 py-0.5">
-                                <span className="flex gap-1">
-                                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:-0.3s]" />
-                                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce [animation-delay:-0.15s]" />
-                                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-bounce" />
-                                </span>
-                                <span className="text-[11px] font-bold text-blue-600 dark:text-blue-400 tracking-wide">智能体正全力研判...</span>
-                            </div>
-                        ) : card.verdict ? (
-                            <div className="flex items-start gap-2 min-w-0">
-                                <span className={`shrink-0 text-[10px] font-black px-2 py-0.5 rounded-full leading-tight shadow-sm ${VERDICT_COLORS[card.verdict.direction] ?? VERDICT_COLORS._default}`}>
-                                    {card.verdict.direction}
-                                </span>
-                                <span className={`text-[12px] font-medium leading-[1.4] ${card.sumText} line-clamp-2`}>
-                                    {card.verdict.reason}
-                                </span>
-                            </div>
-                        ) : (
-                            <div className="flex items-center gap-1.5">
-                                <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
-                                <span className="text-[12px] text-emerald-600 dark:text-emerald-400 font-bold">交付深度研报完成</span>
-                            </div>
-                        )}
-                    </div>
-                )}
-            </div>
-        </button>
+            {done && !verdict && (
+                <div className="flex items-center gap-1.5 mt-2">
+                    <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
+                    <span className="text-[12px] text-emerald-600 dark:text-emerald-400 font-bold">完成</span>
+                </div>
+            )}
+        </div>
     )
+}
+
+// 分组背景标签节点
+function GroupLabelNode({ data }: NodeProps<Node<{ label: string; width: number; height: number; [key: string]: unknown }>>) {
+    return (
+        <div
+            className="rounded-2xl border-2 border-dashed border-slate-200 dark:border-slate-700/60 pointer-events-none"
+            style={{ width: data.width, height: data.height }}
+        >
+            <div className="absolute -top-3 left-4 px-2 bg-white dark:bg-slate-900">
+                <span className="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest">
+                    {data.label}
+                </span>
+            </div>
+        </div>
+    )
+}
+
+const nodeTypes = {
+    agent: memo(AgentNodeComponent),
+    groupLabel: memo(GroupLabelNode),
 }
 
 // ── 主组件 ────────────────────────────────────────────────────────────────────
@@ -261,32 +278,117 @@ export default function AgentCollaboration({ onSelectSection, onOpenDebate, sele
     const { agents, isAnalyzing, streamingSections, report, currentHorizon } = useAnalysisStore()
 
     const cards = useMemo(() => META.map((meta) => {
-        const agent       = agents.find(a => a.name === meta.name)
+        const agent = agents.find(a => a.name === meta.name)
         const streamState = meta.section ? streamingSections[meta.section] : undefined
-        const stored      = meta.section ? (report?.[meta.section as keyof typeof report] as string | undefined) : undefined
-        const src         = streamState?.displayed || stored || ''
-        
-        // 判定 Agent 是否参与：如果是分析中，且不是 skipped
+        const stored = meta.section ? (report?.[meta.section as keyof typeof report] as string | undefined) : undefined
+        const src = streamState?.displayed || stored || ''
         const isParticipating = isAnalyzing ? (agent ? agent.status !== 'skipped' : false) : true
 
         return {
-            ...meta,
-            status:      (agent?.status ?? 'pending') as AgentStatus,
+            meta,
+            status: (agent?.status ?? 'pending') as AgentStatus,
             isStreaming: !!streamState?.isTyping,
-            verdict:     extractVerdict(src),
+            verdict: extractVerdict(src),
             isParticipating,
         }
     }), [agents, report, streamingSections, isAnalyzing])
 
-    const cardMap = new Map(cards.map(c => [c.name, c]))
+    const cardMap = useMemo(() => new Map(cards.map(c => [c.meta.name, c])), [cards])
     const doneN = cards.filter(c => c.status === 'completed').length
-    // 进度分母：排除 skipped，无论是否正在分析
     const participatingCount = cards.filter(c => c.status !== 'skipped').length
+
+    // 构建 React Flow 节点
+    const nodes: Node[] = useMemo(() => {
+        const agentNodes: Node[] = cards.map(card => ({
+            id: card.meta.name,
+            type: 'agent',
+            position: NODE_POSITIONS[card.meta.name] ?? { x: 0, y: 0 },
+            data: {
+                meta: card.meta,
+                status: card.status,
+                verdict: card.verdict,
+                isParticipating: card.isParticipating,
+                selected: !!card.meta.section && card.meta.section === selectedSection,
+            } satisfies AgentNodeData,
+        }))
+
+        const labelNodes: Node[] = GROUP_LABELS.map(g => ({
+            id: g.id,
+            type: 'groupLabel',
+            position: g.position,
+            data: { label: g.label, width: g.width, height: g.height },
+            selectable: false,
+            draggable: false,
+            zIndex: -1,
+        }))
+
+        return [...labelNodes, ...agentNodes]
+    }, [cards, selectedSection])
+
+    // 构建 React Flow 边
+    const edges: Edge[] = useMemo(() => {
+        return EDGE_DEFS.map((def, i) => {
+            const sourceCard = cardMap.get(def.source)
+            const targetCard = cardMap.get(def.target)
+            const sourceDone = sourceCard?.status === 'completed'
+            const targetActive = targetCard?.status === 'in_progress'
+
+            const color = sourceDone ? '#10b981' : targetActive ? '#3b82f6' : '#cbd5e1'
+
+            return {
+                id: `e-${i}`,
+                source: def.source,
+                target: def.target,
+                sourceHandle: def.sourceHandle ?? 'right',
+                targetHandle: def.targetHandle ?? 'left',
+                type: 'default',
+                animated: targetActive,
+                label: def.label,
+                labelStyle: { fontSize: 10, fontWeight: 600, fill: '#64748b' },
+                labelBgStyle: { fill: 'white', fillOpacity: 0.85 },
+                labelBgPadding: [4, 2] as [number, number],
+                labelBgBorderRadius: 4,
+                style: {
+                    stroke: color,
+                    strokeWidth: def.thin ? 1 : 1.5,
+                    opacity: def.thin ? 0.6 : 1,
+                },
+                markerEnd: {
+                    type: MarkerType.ArrowClosed,
+                    color,
+                    width: 16,
+                    height: 16,
+                },
+                ...(def.bidirectional && {
+                    markerStart: {
+                        type: MarkerType.ArrowClosed,
+                        color,
+                        width: 16,
+                        height: 16,
+                    },
+                }),
+            } satisfies Edge
+        })
+    }, [cardMap])
+
+    // 节点点击
+    const handleNodeClick = useCallback((_: React.MouseEvent, node: Node) => {
+        const card = cardMap.get(node.id)
+        if (!card) return
+        if (card.status !== 'completed' && card.status !== 'in_progress') return
+
+        if (card.meta.debate) {
+            onOpenDebate(card.meta.debate)
+            if (card.meta.section) onSelectSection(card.meta.section)
+        } else if (card.meta.section) {
+            onSelectSection(card.meta.section === selectedSection ? undefined : card.meta.section)
+        }
+    }, [cardMap, selectedSection, onSelectSection, onOpenDebate])
 
     return (
         <section className="card relative overflow-hidden bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800">
             {/* 标题栏 */}
-            <div className="flex items-center justify-between mb-8 relative z-10 border-b border-slate-100 dark:border-slate-800 pb-4">
+            <div className="flex items-center justify-between mb-2 relative z-10 border-b border-slate-100 dark:border-slate-800 pb-4">
                 <div className="flex items-center gap-3">
                     <div className={`w-3 h-3 rounded-full ${isAnalyzing ? 'bg-blue-500 animate-pulse shadow-[0_0_12px_#3b82f6]' : 'bg-slate-300'}`} />
                     <h3 className="text-lg font-black text-slate-900 dark:text-white tracking-tighter uppercase">
@@ -298,8 +400,8 @@ export default function AgentCollaboration({ onSelectSection, onOpenDebate, sele
                         {currentHorizon && (
                             <span className={`px-3 py-1 rounded-full text-[11px] font-black tracking-widest border animate-in fade-in duration-300 ${
                                 currentHorizon === 'short'
-                                ? 'bg-blue-600/10 text-blue-600 dark:text-blue-400 border-blue-400/30'
-                                : 'bg-purple-600/10 text-purple-600 dark:text-purple-400 border-purple-400/30'
+                                    ? 'bg-blue-600/10 text-blue-600 dark:text-blue-400 border-blue-400/30'
+                                    : 'bg-purple-600/10 text-purple-600 dark:text-purple-400 border-purple-400/30'
                             }`}>
                                 {currentHorizon === 'short' ? '⚡ 短线视角' : '🔭 中线视角'}
                             </span>
@@ -314,81 +416,28 @@ export default function AgentCollaboration({ onSelectSection, onOpenDebate, sele
                 )}
             </div>
 
-            <div className="space-y-8 relative z-10">
-                {GROUPS.map((group, gi) => {
-                    const gc = group.agents.map(n => cardMap.get(n)).filter(Boolean) as CardData[]
-                    const anyParticipating = gc.some(c => c.isParticipating)
-                    const anyAct = gc.some(c => c.status === 'in_progress')
-                    const allDone = gc.every(c => !c.isParticipating || c.status === 'completed' || c.status === 'skipped')
-                    
-                    if (isAnalyzing && !anyParticipating) return null
-
-                    return (
-                        <div key={group.title} className="animate-in fade-in duration-700">
-                            {/* 分组标题与预判光流 */}
-                            <div className="flex items-center gap-4 mb-5">
-                                <div className={`relative flex items-center justify-center w-8 h-8 rounded-xl text-[12px] font-black transition-all duration-500 shadow-sm ${
-                                    anyAct ? 'bg-blue-600 text-white rotate-6 shadow-blue-400/40' : 
-                                    allDone && anyParticipating ? 'bg-emerald-500 text-white' : 'bg-slate-100 text-slate-400 dark:bg-slate-800'
-                                }`}>
-                                    {gi + 1}
-                                    {anyAct && <div className="absolute inset-0 rounded-xl border-2 border-blue-500 animate-ping opacity-30" />}
-                                </div>
-                                <span className={`text-sm font-black uppercase tracking-widest transition-colors duration-300 ${
-                                    anyAct  ? 'text-blue-600 dark:text-blue-400'
-                                    : allDone && anyParticipating ? 'text-emerald-600 dark:text-emerald-400'
-                                    : 'text-slate-500 dark:text-slate-400'
-                                }`}>
-                                    {group.title}
-                                </span>
-                                <div className="relative flex-1 h-[2px] bg-slate-100 dark:bg-slate-800/50 rounded-full overflow-hidden">
-                                    {allDone && anyParticipating && (
-                                        <div className="absolute inset-0 bg-emerald-500/40" />
-                                    )}
-                                </div>
-                            </div>
-
-                            {/* Agent 磁贴网格 */}
-                            <div className={`grid gap-5 ${group.cols}`}>
-                                {gc.map(card => (
-                                    <AgentCard
-                                        key={card.name}
-                                        card={card}
-                                        selected={!!card.section && card.section === selectedSection}
-                                        onClick={() => {
-                                            if (card.debate) {
-                                                onOpenDebate(card.debate)
-                                                if (card.section) onSelectSection(card.section)
-                                            } else if (card.section) {
-                                                onSelectSection(card.section === selectedSection ? undefined : card.section)
-                                            }
-                                        }}
-                                    />
-                                ))}
-                            </div>
-                        </div>
-                    )
-                })}
+            {/* React Flow 画布 */}
+            <div className="h-[700px] w-full">
+                <ReactFlow
+                    nodes={nodes}
+                    edges={edges}
+                    nodeTypes={nodeTypes}
+                    onNodeClick={handleNodeClick}
+                    defaultViewport={{ x: 20, y: 20, zoom: 1 }}
+                    nodesDraggable={false}
+                    nodesConnectable={false}
+                    nodesFocusable={false}
+                    edgesFocusable={false}
+                    panOnDrag
+                    panOnScroll={false}
+                    zoomOnScroll={false}
+                    zoomOnPinch={false}
+                    zoomOnDoubleClick={false}
+                    preventScrolling={false}
+                    translateExtent={[[-40, -40], [1730, 660]]}
+                    proOptions={{ hideAttribution: true }}
+                />
             </div>
-
-            <style dangerouslySetInnerHTML={{ __html: `
-                @keyframes flowing-light {
-                    0% { background-position: 200% 0; }
-                    100% { background-position: -200% 0; }
-                }
-                .animate-flowing-light {
-                    animation: flowing-light 2s linear infinite;
-                }
-                @keyframes gradient-x {
-                    0% { background-position: 0% 50%; }
-                    50% { background-position: 100% 50%; }
-                    100% { background-position: 0% 50%; }
-                }
-                .animate-gradient-x {
-                    background-size: 200% 200%;
-                    animation: gradient-x 8s ease infinite;
-                }
-            `}} />
         </section>
     )
 }


### PR DESCRIPTION
## Summary
- 将 Agent 协同工作流从纵向卡片网格布局重构为水平节点连线流程图，对标 `assets/schema.png`
- 引入 `@xyflow/react` (React Flow v12)，节点固定 1:1 尺寸显示，小屏通过拖拽平移查看
- 关键连线带标签（辩论、投资计划、交易方案），边颜色随 Agent 状态动态变化（灰→蓝动画→绿）

## Test plan
- [ ] 大屏（≥1920px）验证流程图完整展示
- [ ] 13 寸笔记本验证拖拽平移功能正常
- [ ] 启动分析任务验证节点状态动画、连线颜色变化
- [ ] 点击节点验证报告面板/辩论抽屉正常打开