### PR TITLE
fix: job timeout guard + fast-fail on LLM errors + scheduler throttling

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -155,8 +155,10 @@ async def _scheduler_loop():
                     for task in tasks
                 ]
 
-                _log(f"[Scheduler] Launching {len(task_snapshots)} tasks")
-                for snap in task_snapshots:
+                _log(f"[Scheduler] Launching {len(task_snapshots)} tasks (staggered)")
+                for i, snap in enumerate(task_snapshots):
+                    if i > 0:
+                        await asyncio.sleep(1)
                     _create_tracked_task(_run_scheduled_job(snap, today))
 
         except Exception as e:
@@ -344,6 +346,9 @@ _cn_stock_map_lock = Lock()
 
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+_JOB_TIMEOUT = int(os.getenv("TA_JOB_TIMEOUT", "600"))  # seconds
 
 
 def _create_tracked_task(coro) -> asyncio.Task:
@@ -1354,11 +1359,38 @@ async def _run_job(
     user_id: Optional[str] = None,
     request_source: str = "api",
 ) -> None:
+    try:
+        await asyncio.wait_for(
+            _run_job_inner(job_id, request, stream_events, save_report, user_id, request_source),
+            timeout=_JOB_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        err_msg = f"任务超时（超过 {_JOB_TIMEOUT} 秒），已自动终止"
+        _log(f"[Job {job_id}] {err_msg}")
+        _set_job(job_id, status="failed", error=err_msg, finished_at=_utcnow_iso())
+        try:
+            def _record_timeout():
+                with get_db_ctx() as db:
+                    report_service.mark_report_failed(db, job_id, err_msg)
+            await asyncio.to_thread(_record_timeout)
+        except Exception:
+            pass
+        _emit_job_event(job_id, "job.failed", {"job_id": job_id, "error": err_msg})
+
+
+async def _run_job_inner(
+    job_id: str,
+    request: AnalyzeRequest,
+    stream_events: bool = False,
+    save_report: bool = True,
+    user_id: Optional[str] = None,
+    request_source: str = "api",
+) -> None:
     job_start_t = time.time()
     # Normalize for logic but keep original for display
     display_name = request.symbol
     normalized_symbol = _normalize_symbol(request.symbol)
-    
+
     # ── Step 0: Initialize report in DB (short-lived session) ──
     def _init_and_configure():
         with get_db_ctx() as db:
@@ -1596,6 +1628,7 @@ async def _run_job(
                             await asyncio.to_thread(_horizon_partial_update, db_updates)
                 except Exception as e:
                     _log(f"Error during horizon streaming ({horizon}): {e}")
+                    raise
                 finally:
                     current_tracker_var.reset(_tracker_token)
 
@@ -1610,9 +1643,13 @@ async def _run_job(
                 *[_process_horizon(h) for h in request.horizons],
                 return_exceptions=True,
             )
+            horizon_errors = []
             for i, r in enumerate(results):
                 if isinstance(r, Exception):
                     _log(f"Horizon '{request.horizons[i]}' failed: {r}")
+                    horizon_errors.append(f"{request.horizons[i]}: {r}")
+            if horizon_errors:
+                raise RuntimeError(f"Horizon analysis failed: {'; '.join(horizon_errors)}")
 
             graph.data_collector.evict(ticker, request.trade_date)
 
@@ -2211,7 +2248,7 @@ async def _stream_job_events(job_id: str):
     yield _sse_pack("job.ready", {"job_id": job_id})
     while True:
         try:
-            event = await asyncio.wait_for(q.get(), timeout=30)
+            event = await asyncio.wait_for(q.get(), timeout=15)
             yield _sse_pack(event["event"], event["data"])
             if event["event"] in ("job.completed", "job.failed"):
                 yield "event: done\ndata: [DONE]\n\n"


### PR DESCRIPTION
## Summary

- **任务级超时**：`_run_job` 增加 600s 超时（`TA_JOB_TIMEOUT` 可配），超时自动标记 failed 并通知前端
- **快速失败**：horizon streaming 异常不再被吞掉，正确冒泡；`asyncio.gather` 后检查异常，避免残缺报告被标记为 completed
- **调度器节流**：批量定时任务间隔 1s 启动，避免 40+ 任务同时打爆 LLM API
- **SSE ping 间隔 30s → 15s**：防止 Cloudflare 在空闲时断开连接

## 根因分析

3/31 调度器在 12:00 和 13:34 分别一次性启动 41 和 32 个任务，LLM API 响应变慢后任务全部卡在 running 状态（无超时机制），累积 184 个僵尸任务堵死后端，新请求无法处理。

## Test plan

- [ ] 部署后触发一次分析任务，确认正常完成
- [ ] 模拟 LLM 超时（设 `TA_JOB_TIMEOUT=30`），确认任务自动 fail 且前端收到错误
- [ ] 观察下一次调度批量任务，确认间隔启动且不堵塞

🤖 Generated with [Claude Code](https://claude.com/claude-code)