### PR TITLE
定时任务模块升级

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -93,6 +93,7 @@ def init_db() -> None:
     Base.metadata.create_all(bind=engine)
     _ensure_report_schema()
     _ensure_user_schema()
+    _ensure_scheduled_schema()
 
 
 def _ensure_report_schema() -> None:
@@ -116,6 +117,16 @@ def _ensure_report_schema() -> None:
                 conn.execute(text("ALTER TABLE reports ADD COLUMN game_theory_report TEXT"))
             if "volume_price_report" not in columns:
                 conn.execute(text("ALTER TABLE reports ADD COLUMN volume_price_report TEXT"))
+            if "report_source" not in columns:
+                conn.execute(text("ALTER TABLE reports ADD COLUMN report_source VARCHAR(20) DEFAULT 'manual'"))
+            if "scheduled_task_id" not in columns:
+                conn.execute(text("ALTER TABLE reports ADD COLUMN scheduled_task_id VARCHAR(36)"))
+            if "scheduled_task_slot" not in columns:
+                conn.execute(text("ALTER TABLE reports ADD COLUMN scheduled_task_slot VARCHAR(40)"))
+            if "scheduled_frequency" not in columns:
+                conn.execute(text("ALTER TABLE reports ADD COLUMN scheduled_frequency VARCHAR(20)"))
+            if "prompt_snapshot" not in columns:
+                conn.execute(text("ALTER TABLE reports ADD COLUMN prompt_snapshot TEXT"))
     except Exception as e:
         logger.error("Failed to ensure report schema: %s", e)
 
@@ -131,7 +142,10 @@ def _ensure_user_schema() -> None:
                 conn.execute(text("ALTER TABLE users ADD COLUMN email_report_enabled BOOLEAN NOT NULL DEFAULT 1"))
             if "wecom_report_enabled" not in columns:
                 conn.execute(text("ALTER TABLE users ADD COLUMN wecom_report_enabled BOOLEAN NOT NULL DEFAULT 1"))
+
             llm_columns = {row[1] for row in conn.execute(text("PRAGMA table_info(user_llm_configs)"))}
+            if "analysis_prompt" not in llm_columns:
+                conn.execute(text("ALTER TABLE user_llm_configs ADD COLUMN analysis_prompt TEXT"))
             if "wecom_webhook_encrypted" not in llm_columns:
                 conn.execute(text("ALTER TABLE user_llm_configs ADD COLUMN wecom_webhook_encrypted TEXT"))
     except Exception as e:
@@ -139,6 +153,142 @@ def _ensure_user_schema() -> None:
 
     _migrate_tokens_to_hashed()
     _migrate_api_keys_reencrypt()
+
+
+def _ensure_scheduled_schema() -> None:
+    """Migrate scheduled tasks to the 5-slot model for existing SQLite deployments."""
+    try:
+        with engine.begin() as conn:
+            table_info = conn.execute(text("PRAGMA table_info(scheduled_analyses)")).fetchall()
+            if not table_info:
+                return
+
+            columns = {row[1] for row in table_info}
+            needs_rebuild = any(
+                col not in columns
+                for col in (
+                    "task_type",
+                    "task_slot",
+                    "frequency",
+                    "day_of_week",
+                    "day_of_month",
+                    "prompt_mode",
+                    "custom_prompt",
+                    "last_run_key",
+                )
+            )
+
+            create_sql_row = conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='table' AND name='scheduled_analyses'")
+            ).fetchone()
+            create_sql = (create_sql_row[0] if create_sql_row else "") or ""
+            if "uq_scheduled_user_symbol_task_slot" not in create_sql:
+                needs_rebuild = True
+
+            if not needs_rebuild:
+                return
+
+            rows = conn.execute(
+                text(
+                    """
+                    SELECT id, user_id, symbol, horizon, trigger_time, is_active,
+                           last_run_date, last_run_status, last_report_id,
+                           consecutive_failures, created_at, updated_at
+                    FROM scheduled_analyses
+                    """
+                )
+            ).fetchall()
+
+            conn.execute(text("DROP TABLE IF EXISTS scheduled_analyses_new"))
+            conn.execute(
+                text(
+                    """
+                    CREATE TABLE scheduled_analyses_new (
+                        id VARCHAR(36) PRIMARY KEY,
+                        user_id VARCHAR(64) NOT NULL,
+                        symbol VARCHAR(20) NOT NULL,
+                        task_type VARCHAR(20) NOT NULL DEFAULT 'market_window',
+                        task_slot VARCHAR(40) NOT NULL,
+                        frequency VARCHAR(20) NOT NULL DEFAULT 'trading_day',
+                        horizon VARCHAR(10) DEFAULT 'short',
+                        trigger_time VARCHAR(5) DEFAULT '20:00',
+                        day_of_week INTEGER,
+                        day_of_month INTEGER,
+                        prompt_mode VARCHAR(20) NOT NULL DEFAULT 'merge_global',
+                        custom_prompt TEXT,
+                        is_active BOOLEAN DEFAULT 1,
+                        last_run_key VARCHAR(20),
+                        last_run_date VARCHAR(10),
+                        last_run_status VARCHAR(10),
+                        last_report_id VARCHAR(36),
+                        consecutive_failures INTEGER DEFAULT 0,
+                        created_at DATETIME,
+                        updated_at DATETIME,
+                        CONSTRAINT uq_scheduled_user_symbol_task_slot UNIQUE (user_id, symbol, task_slot)
+                    )
+                    """
+                )
+            )
+
+            for row in rows:
+                horizon = row[3] or "short"
+                trigger_time = row[4] or "20:00"
+                if trigger_time == "08:00":
+                    task_slot = "pre_open_0800"
+                elif trigger_time == "12:00":
+                    task_slot = "midday_1200"
+                elif trigger_time == "20:00":
+                    task_slot = "post_close_2000"
+                elif horizon == "medium":
+                    task_slot = "custom_long"
+                else:
+                    task_slot = "custom_short"
+                task_type = "market_window" if task_slot in {"pre_open_0800", "midday_1200", "post_close_2000"} else "custom_recurring"
+                frequency = "trading_day" if task_type == "market_window" else "daily"
+
+                conn.execute(
+                    text(
+                        """
+                        INSERT OR IGNORE INTO scheduled_analyses_new (
+                            id, user_id, symbol, task_type, task_slot, frequency, horizon,
+                            trigger_time, day_of_week, day_of_month, prompt_mode,
+                            custom_prompt, is_active, last_run_key, last_run_date,
+                            last_run_status, last_report_id, consecutive_failures,
+                            created_at, updated_at
+                        ) VALUES (
+                            :id, :user_id, :symbol, :task_type, :task_slot, :frequency, :horizon,
+                            :trigger_time, NULL, NULL, 'merge_global',
+                            NULL, :is_active, :last_run_key, :last_run_date,
+                            :last_run_status, :last_report_id, :consecutive_failures,
+                            :created_at, :updated_at
+                        )
+                        """
+                    ),
+                    {
+                        "id": row[0],
+                        "user_id": row[1],
+                        "symbol": row[2],
+                        "task_type": task_type,
+                        "task_slot": task_slot,
+                        "frequency": frequency,
+                        "horizon": horizon,
+                        "trigger_time": trigger_time,
+                        "is_active": row[5],
+                        "last_run_key": row[6],
+                        "last_run_date": row[6],
+                        "last_run_status": row[7],
+                        "last_report_id": row[8],
+                        "consecutive_failures": row[9],
+                        "created_at": row[10],
+                        "updated_at": row[11],
+                    },
+                )
+
+            conn.execute(text("DROP TABLE scheduled_analyses"))
+            conn.execute(text("ALTER TABLE scheduled_analyses_new RENAME TO scheduled_analyses"))
+            conn.execute(text("CREATE INDEX IF NOT EXISTS ix_scheduled_analyses_user_id ON scheduled_analyses (user_id)"))
+    except Exception as e:
+        print(f"Warning: Failed to ensure scheduled schema: {e}")
 
 
 def _migrate_tokens_to_hashed() -> None:
@@ -279,6 +429,11 @@ class ReportDB(Base):
     investment_plan = Column(Text, nullable=True)
     trader_investment_plan = Column(Text, nullable=True)
     final_trade_decision = Column(Text, nullable=True)
+    report_source = Column(String(20), default="manual")
+    scheduled_task_id = Column(String(36), nullable=True, index=True)
+    scheduled_task_slot = Column(String(40), nullable=True)
+    scheduled_frequency = Column(String(20), nullable=True)
+    prompt_snapshot = Column(Text, nullable=True)
     
     # Metadata
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
@@ -311,6 +466,11 @@ class ReportDB(Base):
             "investment_plan": self.investment_plan,
             "trader_investment_plan": self.trader_investment_plan,
             "final_trade_decision": self.final_trade_decision,
+            "report_source": self.report_source,
+            "scheduled_task_id": self.scheduled_task_id,
+            "scheduled_task_slot": self.scheduled_task_slot,
+            "scheduled_frequency": self.scheduled_frequency,
+            "prompt_snapshot": self.prompt_snapshot,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -352,6 +512,7 @@ class UserLLMConfigDB(Base):
     deep_think_llm = Column(String(255), nullable=True)
     max_debate_rounds = Column(Integer, nullable=True)
     max_risk_discuss_rounds = Column(Integer, nullable=True)
+    analysis_prompt = Column(Text, nullable=True)
     api_key_encrypted = Column(Text, nullable=True)
     wecom_webhook_encrypted = Column(Text, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
@@ -395,15 +556,23 @@ class WatchlistItemDB(Base):
 
 
 class ScheduledAnalysisDB(Base):
-    """Scheduled daily analysis tasks."""
+    """Scheduled analysis tasks in fixed per-stock slots."""
     __tablename__ = "scheduled_analyses"
 
     id = Column(String(36), primary_key=True)
     user_id = Column(String(64), index=True, nullable=False)
     symbol = Column(String(20), nullable=False)
+    task_type = Column(String(20), nullable=False, default="market_window")
+    task_slot = Column(String(40), nullable=False)
+    frequency = Column(String(20), nullable=False, default="trading_day")
     horizon = Column(String(10), default="short")
     trigger_time = Column(String(5), default="20:00")
+    day_of_week = Column(Integer, nullable=True)
+    day_of_month = Column(Integer, nullable=True)
+    prompt_mode = Column(String(20), nullable=False, default="merge_global")
+    custom_prompt = Column(Text, nullable=True)
     is_active = Column(Boolean, default=True)
+    last_run_key = Column(String(20), nullable=True)
     last_run_date = Column(String(10), nullable=True)
     last_run_status = Column(String(10), nullable=True)
     last_report_id = Column(String(36), nullable=True)
@@ -411,7 +580,7 @@ class ScheduledAnalysisDB(Base):
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
-    __table_args__ = (UniqueConstraint('user_id', 'symbol', name='uq_scheduled_user_symbol'),)
+    __table_args__ = (UniqueConstraint('user_id', 'symbol', 'task_slot', name='uq_scheduled_user_symbol_task_slot'),)
 
 
 class ThsImportConfigDB(Base):

--- a/api/main.py
+++ b/api/main.py
@@ -211,10 +211,8 @@ async def _scheduler_loop():
             today = now.strftime("%Y-%m-%d")
             current_hhmm = now.strftime("%H:%M")
 
-            if not is_cn_trading_day(today):
-                continue
             time_val = now.hour * 60 + now.minute
-            if 8 * 60 < time_val < 20 * 60:
+            if 8 * 60 < time_val < 20 * 60 and current_hhmm != "12:00":
                 continue
 
             with get_db_ctx() as db:
@@ -224,6 +222,7 @@ async def _scheduler_loop():
 
                 # 先标记为"已触发"防止下次循环重复启动
                 for task in tasks:
+                    task.last_run_key = scheduled_service.current_run_key(task, today)
                     task.last_run_date = today
                     task.last_run_status = "running"
                 db.commit()
@@ -235,7 +234,12 @@ async def _scheduler_loop():
                         "id": task.id,
                         "user_id": task.user_id,
                         "symbol": task.symbol,
+                        "task_slot": task.task_slot,
+                        "task_type": task.task_type,
+                        "frequency": task.frequency,
                         "horizon": task.horizon,
+                        "prompt_mode": task.prompt_mode,
+                        "custom_prompt": task.custom_prompt,
                     }
                     for task in tasks
                 ]
@@ -263,9 +267,26 @@ def _build_scheduled_analyze_request(
     symbol: str,
     horizon: str,
     trade_date: str,
+    task: Optional[Dict[str, Any]] = None,
     scheduled_user_context: Optional[Dict[str, Any]] = None,
 ) -> "AnalyzeRequest":
     scheduled_user_context = scheduled_user_context or _build_imported_user_context(db, user_id, symbol)
+    task = task or {}
+    runtime_cfg = _build_runtime_config({}, user_id=user_id, db=db)
+    global_prompt = str(runtime_cfg.get("analysis_prompt") or "").strip()
+    local_prompt = str(task.get("custom_prompt") or "").strip()
+    prompt_mode = task.get("prompt_mode") or "merge_global"
+    if prompt_mode == "override_global":
+        prompt_snapshot = local_prompt
+    elif global_prompt and local_prompt:
+        prompt_snapshot = f"{global_prompt}\n\n{local_prompt}"
+    else:
+        prompt_snapshot = global_prompt or local_prompt or None
+
+    user_notes = scheduled_user_context.get("user_notes")
+    if prompt_snapshot:
+        prompt_note = f"定时分析要求：{prompt_snapshot}"
+        user_notes = f"{user_notes}\n\n{prompt_note}" if user_notes else prompt_note
     return AnalyzeRequest(
         symbol=symbol,
         trade_date=trade_date,
@@ -282,7 +303,12 @@ def _build_scheduled_analyze_request(
         current_position=scheduled_user_context.get("current_position"),
         current_position_pct=scheduled_user_context.get("current_position_pct"),
         average_cost=scheduled_user_context.get("average_cost"),
-        user_notes=scheduled_user_context.get("user_notes"),
+        user_notes=user_notes,
+        report_source="scheduled",
+        scheduled_task_id=task.get("id"),
+        scheduled_task_slot=task.get("task_slot"),
+        scheduled_frequency=task.get("frequency"),
+        prompt_snapshot=prompt_snapshot,
     )
 
 
@@ -352,6 +378,7 @@ async def _run_scheduled_analysis_once(
                     symbol=symbol,
                     horizon=horizon,
                     trade_date=actual_trade_date,
+                    task=task,
                     scheduled_user_context=scheduled_user_context,
                 )
 
@@ -489,6 +516,7 @@ app = FastAPI(
     redoc_url=None if _is_prod else "/redoc",
     openapi_url=None if _is_prod else "/openapi.json",
 )
+init_db()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_allow_origins(),
@@ -763,6 +791,11 @@ class AnalyzeRequest(UserContextInput):
     horizons: List[str] = Field(default_factory=lambda: ["short"], description="分析周期列表，如 ['short'] 或 ['short','medium']")
     # Pre-parsed intent from _ai_extract_symbol_and_date (avoids second LLM call in _run_job)
     user_intent: Optional[Dict[str, Any]] = Field(default=None, description="预解析的用户意图，由 chat_completions 传入")
+    report_source: str = Field(default="manual", description="manual 或 scheduled")
+    scheduled_task_id: Optional[str] = None
+    scheduled_task_slot: Optional[str] = None
+    scheduled_frequency: Optional[str] = None
+    prompt_snapshot: Optional[str] = None
 
 
 class AnalyzeResponse(BaseModel):
@@ -851,6 +884,11 @@ class ReportResponse(BaseModel):
     risk_items: Optional[List[Dict[str, Any]]] = None
     key_metrics: Optional[List[Dict[str, Any]]] = None
     analyst_traces: Optional[List[Dict[str, Any]]] = None
+    report_source: Optional[str] = "manual"
+    scheduled_task_id: Optional[str] = None
+    scheduled_task_slot: Optional[str] = None
+    scheduled_frequency: Optional[str] = None
+    prompt_snapshot: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     waiting_ahead_count: Optional[int] = None
@@ -921,7 +959,12 @@ class ScheduledBatchUpdateRequest(BaseModel):
     item_ids: List[str] = Field(default_factory=list)
     is_active: Optional[bool] = None
     horizon: Optional[str] = None
+    frequency: Optional[str] = None
     trigger_time: Optional[str] = None
+    day_of_week: Optional[int] = None
+    day_of_month: Optional[int] = None
+    prompt_mode: Optional[str] = None
+    custom_prompt: Optional[str] = None
 
 
 class AnnouncementItemResponse(BaseModel):
@@ -980,6 +1023,7 @@ class UserRuntimeConfigResponse(BaseModel):
     backend_url: str
     max_debate_rounds: int
     max_risk_discuss_rounds: int
+    analysis_prompt: str = ""
     has_api_key: bool = False
     has_wecom_webhook: bool = False
     wecom_webhook_display: Optional[str] = None
@@ -995,6 +1039,7 @@ class UserRuntimeConfigUpdateRequest(BaseModel):
     backend_url: Optional[str] = None
     max_debate_rounds: Optional[int] = None
     max_risk_discuss_rounds: Optional[int] = None
+    analysis_prompt: Optional[str] = None
     email_report_enabled: Optional[bool] = None
     wecom_report_enabled: Optional[bool] = None
     api_key: Optional[str] = None
@@ -1098,6 +1143,7 @@ def _user_config_overrides(user_id: Optional[str], db: Optional[Session] = None)
             "deep_think_llm",
             "max_debate_rounds",
             "max_risk_discuss_rounds",
+            "analysis_prompt",
         ):
             value = getattr(user_cfg, key, None)
             if value is not None:
@@ -2078,6 +2124,11 @@ async def _run_job_inner(
                 "confidence": resolved["confidence"],
                 "target_price": resolved["target_price"],
                 "stop_loss_price": resolved["stop_loss_price"],
+                "report_source": request.report_source,
+                "scheduled_task_id": request.scheduled_task_id,
+                "scheduled_task_slot": request.scheduled_task_slot,
+                "scheduled_frequency": request.scheduled_frequency,
+                "prompt_snapshot": request.prompt_snapshot,
             })
 
             # 自动保存报告到数据库
@@ -2098,6 +2149,11 @@ async def _run_job_inner(
                             stop_loss_override=result["stop_loss_price"],
                             report_id=job_id,
                             analyst_traces=result.get("analyst_traces"),
+                            report_source=request.report_source,
+                            scheduled_task_id=request.scheduled_task_id,
+                            scheduled_task_slot=request.scheduled_task_slot,
+                            scheduled_frequency=request.scheduled_frequency,
+                            prompt_snapshot=request.prompt_snapshot,
                         )
                         save_db.commit()
 
@@ -2309,6 +2365,11 @@ async def _run_job_inner(
             "confidence": resolved["confidence"],
             "target_price": resolved["target_price"],
             "stop_loss_price": resolved["stop_loss_price"],
+            "report_source": request.report_source,
+            "scheduled_task_id": request.scheduled_task_id,
+            "scheduled_task_slot": request.scheduled_task_slot,
+            "scheduled_frequency": request.scheduled_frequency,
+            "prompt_snapshot": request.prompt_snapshot,
         })
 
         # 自动保存/收口报告到数据库
@@ -2329,6 +2390,11 @@ async def _run_job_inner(
                         stop_loss_override=result["stop_loss_price"],
                         report_id=job_id,
                         analyst_traces=result.get("analyst_traces"),
+                        report_source=request.report_source,
+                        scheduled_task_id=request.scheduled_task_id,
+                        scheduled_task_slot=request.scheduled_task_slot,
+                        scheduled_frequency=request.scheduled_frequency,
+                        prompt_snapshot=request.prompt_snapshot,
                     )
                     save_db.commit()
 
@@ -3528,7 +3594,7 @@ def delete_backtest(job_id: str) -> Dict:
 
 _CONFIG_ALLOWED_KEYS = {
     "llm_provider", "deep_think_llm", "quick_think_llm",
-    "backend_url", "max_debate_rounds", "max_risk_discuss_rounds",
+    "backend_url", "max_debate_rounds", "max_risk_discuss_rounds", "analysis_prompt",
 }
 _CONFIG_PREFERENCE_KEYS = {"email_report_enabled", "wecom_report_enabled"}
 _CONFIG_MODEL_KEYS = ("llm_provider", "backend_url", "quick_think_llm", "deep_think_llm")
@@ -3775,6 +3841,7 @@ def _config_response_for_user(user: Optional[UserDB], db: Session) -> UserRuntim
         backend_url=cfg["backend_url"],
         max_debate_rounds=cfg["max_debate_rounds"],
         max_risk_discuss_rounds=cfg["max_risk_discuss_rounds"],
+        analysis_prompt=str(cfg.get("analysis_prompt") or ""),
         has_api_key=bool(user_cfg and user_cfg.api_key_encrypted),
         has_wecom_webhook=bool(webhook_url),
         wecom_webhook_display=_mask_wecom_webhook(webhook_url),
@@ -3856,6 +3923,7 @@ def update_runtime_config(
         backend_url=updates.backend_url,
         max_debate_rounds=updates.max_debate_rounds,
         max_risk_discuss_rounds=updates.max_risk_discuss_rounds,
+        analysis_prompt=updates.analysis_prompt,
         api_key=updates.api_key,
         wecom_webhook_url=normalized_wecom_webhook,
         clear_api_key=updates.clear_api_key,
@@ -4281,15 +4349,33 @@ def create_scheduled_analysis(
     db: Session = Depends(get_db),
 ):
     symbol = body.get("symbol", "").strip().upper()
-    horizon = body.get("horizon", "short")
-    trigger_time = body.get("trigger_time", "20:00")
+    task_type = body.get("task_type")
+    task_slot = body.get("task_slot", "")
+    legacy_horizon = body.get("horizon") or "short"
+    legacy_trigger_time = body.get("trigger_time") or "20:00"
+    if not task_type or not task_slot:
+        task_type = "custom_recurring"
+        task_slot = "custom_long" if legacy_horizon == "medium" else "custom_short"
     if not symbol:
         raise HTTPException(400, "symbol is required")
     code_to_name = _get_reverse_stock_map()
     if symbol not in code_to_name:
         raise HTTPException(400, f"未知的股票代码: {symbol}")
     try:
-        item = scheduled_service.create_scheduled(db, current_user.id, symbol, horizon, trigger_time)
+        item = scheduled_service.create_scheduled(
+            db,
+            current_user.id,
+            symbol,
+            task_type=task_type,
+            task_slot=task_slot,
+            frequency=body.get("frequency") or ("daily" if task_type == "custom_recurring" else "trading_day"),
+            horizon=body.get("horizon"),
+            trigger_time=body.get("trigger_time") or legacy_trigger_time,
+            day_of_week=body.get("day_of_week"),
+            day_of_month=body.get("day_of_month"),
+            prompt_mode=body.get("prompt_mode", "merge_global"),
+            custom_prompt=body.get("custom_prompt"),
+        )
         item["name"] = code_to_name.get(symbol, symbol)
         _annotate_scheduled_with_imported_context([item], db, current_user.id)
         return item
@@ -4303,8 +4389,18 @@ def _extract_scheduled_update_kwargs(body: dict) -> dict:
         kwargs["is_active"] = bool(body["is_active"])
     if "horizon" in body:
         kwargs["horizon"] = body["horizon"]
+    if "frequency" in body:
+        kwargs["frequency"] = body["frequency"]
     if "trigger_time" in body:
         kwargs["trigger_time"] = body["trigger_time"]
+    if "day_of_week" in body:
+        kwargs["day_of_week"] = body["day_of_week"]
+    if "day_of_month" in body:
+        kwargs["day_of_month"] = body["day_of_month"]
+    if "prompt_mode" in body:
+        kwargs["prompt_mode"] = body["prompt_mode"]
+    if "custom_prompt" in body:
+        kwargs["custom_prompt"] = body["custom_prompt"]
     return kwargs
 
 

--- a/api/services/auth_service.py
+++ b/api/services/auth_service.py
@@ -249,6 +249,7 @@ def upsert_user_llm_config(
     deep_think_llm: Optional[str] = None,
     max_debate_rounds: Optional[int] = None,
     max_risk_discuss_rounds: Optional[int] = None,
+    analysis_prompt: Optional[str] = None,
     api_key: Optional[str] = None,
     wecom_webhook_url: Optional[str] = None,
     clear_api_key: bool = False,
@@ -272,6 +273,8 @@ def upsert_user_llm_config(
         row.max_debate_rounds = max_debate_rounds
     if max_risk_discuss_rounds is not None:
         row.max_risk_discuss_rounds = max_risk_discuss_rounds
+    if analysis_prompt is not None:
+        row.analysis_prompt = analysis_prompt
 
     if clear_api_key:
         row.api_key_encrypted = None

--- a/api/services/report_service.py
+++ b/api/services/report_service.py
@@ -383,6 +383,11 @@ def create_report(
     target_price_override: Optional[float] = None,
     stop_loss_override: Optional[float] = None,
     report_id: Optional[str] = None,  # If provided, update existing
+    report_source: str = "manual",
+    scheduled_task_id: Optional[str] = None,
+    scheduled_task_slot: Optional[str] = None,
+    scheduled_frequency: Optional[str] = None,
+    prompt_snapshot: Optional[str] = None,
 ) -> ReportDB:
     """Create or finalize a report."""
     resolved = resolve_report_fields(
@@ -422,6 +427,11 @@ def create_report(
         db_report.investment_plan = resolved["investment_plan"]
         db_report.trader_investment_plan = resolved["trader_investment_plan"]
         db_report.final_trade_decision = resolved["final_trade_decision"]
+        db_report.report_source = report_source
+        db_report.scheduled_task_id = scheduled_task_id
+        db_report.scheduled_task_slot = scheduled_task_slot
+        db_report.scheduled_frequency = scheduled_frequency
+        db_report.prompt_snapshot = prompt_snapshot
         db_report.updated_at = now
     else:
         # Create new
@@ -451,6 +461,11 @@ def create_report(
             investment_plan=resolved["investment_plan"],
             trader_investment_plan=resolved["trader_investment_plan"],
             final_trade_decision=resolved["final_trade_decision"],
+            report_source=report_source,
+            scheduled_task_id=scheduled_task_id,
+            scheduled_task_slot=scheduled_task_slot,
+            scheduled_frequency=scheduled_frequency,
+            prompt_snapshot=prompt_snapshot,
             created_at=now,
             updated_at=now,
         )

--- a/api/services/scheduled_service.py
+++ b/api/services/scheduled_service.py
@@ -1,34 +1,171 @@
 """Scheduled analysis service for database operations."""
 
-from typing import Iterable, List, Optional
+from __future__ import annotations
+
+from calendar import monthrange
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, Iterable, List, Optional
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
 from api.database import ScheduledAnalysisDB
+from tradingagents.dataflows.trade_calendar import is_cn_trading_day
 
-MAX_SCHEDULED_ITEMS = 10
-
-# 非交易时间窗口：15:00~次日9:15 允许设置
 VALID_HORIZONS = {"short", "medium"}
+VALID_TASK_TYPES = {"market_window", "custom_recurring"}
+VALID_PROMPT_MODES = {"merge_global", "override_global"}
+VALID_FREQUENCIES = {"trading_day", "daily", "weekly", "monthly"}
+MARKET_WINDOW_SLOTS = {
+    "pre_open_0800": {"time": "08:00", "label": "开盘前"},
+    "midday_1200": {"time": "12:00", "label": "午间"},
+    "post_close_2000": {"time": "20:00", "label": "收盘后"},
+}
+CUSTOM_SLOTS = {
+    "custom_short": {"horizon": "short", "label": "自定义短线"},
+    "custom_long": {"horizon": "medium", "label": "自定义长期"},
+}
+TASK_SLOT_META = {**MARKET_WINDOW_SLOTS, **CUSTOM_SLOTS}
+MAX_SCHEDULED_ITEMS = 5
+
+
+def _parse_ymd(date_str: str) -> date:
+    return datetime.strptime(date_str, "%Y-%m-%d").date()
 
 
 def _validate_trigger_time(t: str) -> str:
-    """Validate HH:MM format. Allowed: 20:00~23:59 or 00:00~08:00."""
+    """Validate HH:MM format. Allowed: 20:00~23:59 or 00:00~08:00 or exactly 12:00."""
     parts = t.strip().split(":")
     if len(parts) != 2:
         raise ValueError("时间格式错误，请使用 HH:MM")
     try:
         hh, mm = int(parts[0]), int(parts[1])
-    except ValueError:
-        raise ValueError("时间格式错误，请使用 HH:MM")
+    except ValueError as exc:
+        raise ValueError("时间格式错误，请使用 HH:MM") from exc
     if not (0 <= hh <= 23 and 0 <= mm <= 59):
         raise ValueError("时间格式错误，请使用 HH:MM")
     time_val = hh * 60 + mm
-    # Allowed: 20:00 (1200) ~ 23:59 (1439) or 00:00 (0) ~ 08:00 (480)
+    if time_val == 12 * 60:
+        return f"{hh:02d}:{mm:02d}"
     if 8 * 60 < time_val < 20 * 60:
-        raise ValueError("定时时间仅允许 20:00~次日 08:00（避免影响白天使用）")
+        raise ValueError("定时时间仅允许 20:00~次日 08:00，或固定午间 12:00")
     return f"{hh:02d}:{mm:02d}"
+
+
+def _slot_label(task_slot: str) -> str:
+    return TASK_SLOT_META.get(task_slot, {}).get("label", task_slot)
+
+
+def _validate_slot(task_type: str, task_slot: str) -> None:
+    if task_type == "market_window":
+        if task_slot not in MARKET_WINDOW_SLOTS:
+            raise ValueError("交易日窗口任务槽位无效")
+        return
+    if task_type == "custom_recurring":
+        if task_slot not in CUSTOM_SLOTS:
+            raise ValueError("自定义任务槽位无效")
+        return
+    raise ValueError("task_type 必须为 market_window 或 custom_recurring")
+
+
+def _normalize_create_payload(
+    *,
+    task_type: str,
+    task_slot: str,
+    frequency: Optional[str],
+    horizon: Optional[str],
+    trigger_time: Optional[str],
+    day_of_week: Optional[int],
+    day_of_month: Optional[int],
+    prompt_mode: str,
+    custom_prompt: Optional[str],
+) -> Dict[str, Any]:
+    if task_type not in VALID_TASK_TYPES:
+        raise ValueError("task_type 必须为 market_window 或 custom_recurring")
+    _validate_slot(task_type, task_slot)
+
+    if prompt_mode not in VALID_PROMPT_MODES:
+        raise ValueError("prompt_mode 必须为 merge_global 或 override_global")
+
+    custom_prompt = (custom_prompt or "").strip() or None
+
+    if task_type == "market_window":
+        normalized_frequency = "trading_day"
+        normalized_horizon = "short"
+        normalized_trigger_time = MARKET_WINDOW_SLOTS[task_slot]["time"]
+        normalized_day_of_week = None
+        normalized_day_of_month = None
+    else:
+        normalized_frequency = (frequency or "daily").strip()
+        if normalized_frequency not in {"daily", "weekly", "monthly"}:
+            raise ValueError("自定义任务频率必须为 daily、weekly 或 monthly")
+        normalized_horizon = CUSTOM_SLOTS[task_slot]["horizon"]
+        normalized_trigger_time = _validate_trigger_time(trigger_time or "20:00")
+        normalized_day_of_week = None
+        normalized_day_of_month = None
+        if normalized_frequency == "weekly":
+            if day_of_week is None or not (0 <= int(day_of_week) <= 6):
+                raise ValueError("weekly 任务需要 day_of_week，范围为 0-6")
+            normalized_day_of_week = int(day_of_week)
+        elif normalized_frequency == "monthly":
+            if day_of_month is None or not (1 <= int(day_of_month) <= 31):
+                raise ValueError("monthly 任务需要 day_of_month，范围为 1-31")
+            normalized_day_of_month = int(day_of_month)
+
+    if normalized_horizon not in VALID_HORIZONS:
+        raise ValueError("horizon 必须为 short 或 medium")
+
+    return {
+        "task_type": task_type,
+        "task_slot": task_slot,
+        "frequency": normalized_frequency,
+        "horizon": normalized_horizon,
+        "trigger_time": normalized_trigger_time,
+        "day_of_week": normalized_day_of_week,
+        "day_of_month": normalized_day_of_month,
+        "prompt_mode": prompt_mode,
+        "custom_prompt": custom_prompt,
+    }
+
+
+def _period_key(freq: str, current_date: date) -> str:
+    if freq in {"trading_day", "daily"}:
+        return current_date.strftime("%Y-%m-%d")
+    if freq == "weekly":
+        iso = current_date.isocalendar()
+        return f"{iso.year}-W{iso.week:02d}"
+    return current_date.strftime("%Y-%m")
+
+
+def _monthly_due_date(year: int, month: int, day_of_month: int) -> date:
+    last_day = monthrange(year, month)[1]
+    candidate = date(year, month, min(day_of_month, last_day))
+    cur = candidate
+    while cur.month == month:
+        if is_cn_trading_day(cur.strftime("%Y-%m-%d")):
+            return cur
+        cur -= timedelta(days=1)
+    cur = candidate + timedelta(days=1)
+    while cur.month == month:
+        if is_cn_trading_day(cur.strftime("%Y-%m-%d")):
+            return cur
+        cur += timedelta(days=1)
+    return candidate
+
+
+def _task_matches_date(task: ScheduledAnalysisDB, current_date: date) -> bool:
+    current_ymd = current_date.strftime("%Y-%m-%d")
+    if task.task_type == "market_window":
+        return is_cn_trading_day(current_ymd)
+    if task.frequency == "daily":
+        return True
+    if task.frequency == "weekly":
+        return task.day_of_week == current_date.weekday()
+    if task.frequency == "monthly":
+        if not task.day_of_month:
+            return False
+        return _monthly_due_date(current_date.year, current_date.month, task.day_of_month) == current_date
+    return False
 
 
 def list_scheduled(db: Session, user_id: str) -> List[dict]:
@@ -36,7 +173,7 @@ def list_scheduled(db: Session, user_id: str) -> List[dict]:
     items = (
         db.query(ScheduledAnalysisDB)
         .filter(ScheduledAnalysisDB.user_id == user_id)
-        .order_by(ScheduledAnalysisDB.created_at)
+        .order_by(ScheduledAnalysisDB.symbol, ScheduledAnalysisDB.task_slot, ScheduledAnalysisDB.created_at)
         .all()
     )
     return [_to_dict(item) for item in items]
@@ -100,44 +237,103 @@ def _apply_scheduled_updates(item: ScheduledAnalysisDB, **kwargs) -> None:
         item.is_active = kwargs["is_active"]
         if kwargs["is_active"]:
             item.consecutive_failures = 0
-    if "horizon" in kwargs:
-        item.horizon = _validate_horizon(kwargs["horizon"])
-    if "trigger_time" in kwargs:
-        item.trigger_time = _validate_trigger_time(kwargs["trigger_time"])
+    if "prompt_mode" in kwargs:
+        prompt_mode = kwargs["prompt_mode"]
+        if prompt_mode not in VALID_PROMPT_MODES:
+            raise ValueError("prompt_mode 必须为 merge_global 或 override_global")
+        item.prompt_mode = prompt_mode
+    if "custom_prompt" in kwargs:
+        item.custom_prompt = (kwargs["custom_prompt"] or "").strip() or None
+
+    if item.task_type == "custom_recurring":
+        if "horizon" in kwargs:
+            horizon = _validate_horizon(kwargs["horizon"])
+            item.horizon = horizon
+            item.task_slot = "custom_long" if horizon == "medium" else "custom_short"
+        if "frequency" in kwargs:
+            frequency = kwargs["frequency"]
+            if frequency not in {"daily", "weekly", "monthly"}:
+                raise ValueError("自定义任务频率必须为 daily、weekly 或 monthly")
+            item.frequency = frequency
+            if frequency != "weekly":
+                item.day_of_week = None
+            if frequency != "monthly":
+                item.day_of_month = None
+        if "trigger_time" in kwargs:
+            item.trigger_time = _validate_trigger_time(kwargs["trigger_time"])
+        if "day_of_week" in kwargs:
+            value = kwargs["day_of_week"]
+            if value is None:
+                item.day_of_week = None
+            elif not (0 <= int(value) <= 6):
+                raise ValueError("day_of_week 范围必须为 0-6")
+            else:
+                item.day_of_week = int(value)
+        if "day_of_month" in kwargs:
+            value = kwargs["day_of_month"]
+            if value is None:
+                item.day_of_month = None
+            elif not (1 <= int(value) <= 31):
+                raise ValueError("day_of_month 范围必须为 1-31")
+            else:
+                item.day_of_month = int(value)
+        if item.frequency == "weekly" and item.day_of_week is None:
+            raise ValueError("weekly 任务需要 day_of_week，范围为 0-6")
+        if item.frequency == "monthly" and item.day_of_month is None:
+            raise ValueError("monthly 任务需要 day_of_month，范围为 1-31")
+    else:
+        item.frequency = "trading_day"
+        item.trigger_time = MARKET_WINDOW_SLOTS[item.task_slot]["time"]
+        item.day_of_week = None
+        item.day_of_month = None
+        item.horizon = "short"
 
 
 def create_scheduled(
     db: Session,
     user_id: str,
     symbol: str,
-    horizon: str = "short",
-    trigger_time: str = "20:00",
+    *,
+    task_type: str,
+    task_slot: str,
+    frequency: Optional[str] = None,
+    horizon: Optional[str] = None,
+    trigger_time: Optional[str] = None,
+    day_of_week: Optional[int] = None,
+    day_of_month: Optional[int] = None,
+    prompt_mode: str = "merge_global",
+    custom_prompt: Optional[str] = None,
 ) -> dict:
     """Create a scheduled analysis task."""
-    count = db.query(ScheduledAnalysisDB).filter(
-        ScheduledAnalysisDB.user_id == user_id
-    ).count()
-    if count >= MAX_SCHEDULED_ITEMS:
-        raise ValueError(f"定时分析数量已达上限 ({MAX_SCHEDULED_ITEMS})")
+    normalized = _normalize_create_payload(
+        task_type=task_type,
+        task_slot=task_slot,
+        frequency=frequency,
+        horizon=horizon,
+        trigger_time=trigger_time,
+        day_of_week=day_of_week,
+        day_of_month=day_of_month,
+        prompt_mode=prompt_mode,
+        custom_prompt=custom_prompt,
+    )
 
     existing = (
         db.query(ScheduledAnalysisDB)
-        .filter(ScheduledAnalysisDB.user_id == user_id, ScheduledAnalysisDB.symbol == symbol)
+        .filter(
+            ScheduledAnalysisDB.user_id == user_id,
+            ScheduledAnalysisDB.symbol == symbol,
+            ScheduledAnalysisDB.task_slot == normalized["task_slot"],
+        )
         .first()
     )
     if existing:
-        raise ValueError(f"{symbol} 已有定时分析任务")
-
-    horizon = _validate_horizon(horizon)
-
-    trigger_time = _validate_trigger_time(trigger_time)
+        raise ValueError(f"{symbol} 的 {_slot_label(normalized['task_slot'])} 任务已存在")
 
     item = ScheduledAnalysisDB(
         id=uuid4().hex,
         user_id=user_id,
         symbol=symbol,
-        horizon=horizon,
-        trigger_time=trigger_time,
+        **normalized,
     )
     db.add(item)
     db.commit()
@@ -152,11 +348,7 @@ def ensure_scheduled_for_symbols(
     horizon: str = "short",
     trigger_time: str = "20:00",
 ) -> dict:
-    """Ensure the given symbols exist in scheduled tasks without duplicating existing items."""
-
-    horizon = _validate_horizon(horizon)
-
-    trigger_time = _validate_trigger_time(trigger_time)
+    """Ensure each symbol has a default post-close scheduled task."""
 
     existing_items = (
         db.query(ScheduledAnalysisDB)
@@ -164,8 +356,7 @@ def ensure_scheduled_for_symbols(
         .order_by(ScheduledAnalysisDB.created_at)
         .all()
     )
-    existing_symbols = {item.symbol for item in existing_items}
-    remaining_slots = max(0, MAX_SCHEDULED_ITEMS - len(existing_items))
+    existing_pairs = {(item.symbol, item.task_slot) for item in existing_items}
 
     created: list[str] = []
     existing: list[str] = []
@@ -178,12 +369,9 @@ def ensure_scheduled_for_symbols(
             continue
         seen.add(symbol)
 
-        if symbol in existing_symbols:
+        slot_pair = (symbol, "post_close_2000")
+        if slot_pair in existing_pairs:
             existing.append(symbol)
-            continue
-
-        if remaining_slots <= 0:
-            skipped_limit.append(symbol)
             continue
 
         db.add(
@@ -191,13 +379,16 @@ def ensure_scheduled_for_symbols(
                 id=uuid4().hex,
                 user_id=user_id,
                 symbol=symbol,
-                horizon=horizon,
-                trigger_time=trigger_time,
+                task_type="market_window",
+                task_slot="post_close_2000",
+                frequency="trading_day",
+                horizon="short",
+                trigger_time="20:00",
+                prompt_mode="merge_global",
             )
         )
-        existing_symbols.add(symbol)
+        existing_pairs.add(slot_pair)
         created.append(symbol)
-        remaining_slots -= 1
 
     if created:
         db.flush()
@@ -218,6 +409,22 @@ def update_scheduled(db: Session, user_id: str, item_id: str, **kwargs) -> Optio
     )
     if not item:
         return None
+
+    if "horizon" in kwargs and item.task_type == "custom_recurring":
+        target_horizon = _validate_horizon(kwargs["horizon"])
+        target_slot = "custom_long" if target_horizon == "medium" else "custom_short"
+        duplicate = (
+            db.query(ScheduledAnalysisDB)
+            .filter(
+                ScheduledAnalysisDB.user_id == user_id,
+                ScheduledAnalysisDB.symbol == item.symbol,
+                ScheduledAnalysisDB.task_slot == target_slot,
+                ScheduledAnalysisDB.id != item.id,
+            )
+            .first()
+        )
+        if duplicate:
+            raise ValueError(f"{item.symbol} 的 {_slot_label(target_slot)} 任务已存在")
 
     _apply_scheduled_updates(item, **kwargs)
 
@@ -254,7 +461,23 @@ def batch_update_scheduled(
         raise ValueError("部分定时任务不存在或已失效，请刷新后重试")
 
     for item_id in normalized_ids:
-        _apply_scheduled_updates(item_map[item_id], **kwargs)
+        item = item_map[item_id]
+        if "horizon" in kwargs and item.task_type == "custom_recurring":
+            target_horizon = _validate_horizon(kwargs["horizon"])
+            target_slot = "custom_long" if target_horizon == "medium" else "custom_short"
+            duplicate = (
+                db.query(ScheduledAnalysisDB)
+                .filter(
+                    ScheduledAnalysisDB.user_id == user_id,
+                    ScheduledAnalysisDB.symbol == item.symbol,
+                    ScheduledAnalysisDB.task_slot == target_slot,
+                    ScheduledAnalysisDB.id != item.id,
+                )
+                .first()
+            )
+            if duplicate:
+                raise ValueError(f"{item.symbol} 的 {_slot_label(target_slot)} 任务已存在")
+        _apply_scheduled_updates(item, **kwargs)
 
     db.commit()
     for item in items:
@@ -312,24 +535,37 @@ def batch_delete_scheduled(db: Session, user_id: str, item_ids: Iterable[str]) -
     }
 
 
-def get_pending_tasks(db: Session, today: str, current_hhmm: str) -> List[ScheduledAnalysisDB]:
-    """Get all active tasks that haven't run today and whose trigger time has passed."""
+def get_pending_tasks(db: Session, current_date_str: str, current_hhmm: str) -> List[ScheduledAnalysisDB]:
+    """Get all active tasks whose cycle is due and trigger time has passed."""
+    current_date = _parse_ymd(current_date_str)
     all_active = (
         db.query(ScheduledAnalysisDB)
-        .filter(
-            ScheduledAnalysisDB.is_active == True,
-            (ScheduledAnalysisDB.last_run_date != today) | (ScheduledAnalysisDB.last_run_date == None),
-        )
+        .filter(ScheduledAnalysisDB.is_active == True)
         .all()
     )
-    # Filter by trigger_time <= current_hhmm
-    return [t for t in all_active if (t.trigger_time or "20:00") <= current_hhmm]
+    pending: List[ScheduledAnalysisDB] = []
+    for task in all_active:
+        if not _task_matches_date(task, current_date):
+            continue
+        if (task.trigger_time or "20:00") > current_hhmm:
+            continue
+        run_key = _period_key(task.frequency or "daily", current_date)
+        if task.last_run_key == run_key:
+            continue
+        pending.append(task)
+    return pending
+
+
+def current_run_key(task: ScheduledAnalysisDB, trade_date: str) -> str:
+    return _period_key(task.frequency or "daily", _parse_ymd(trade_date))
 
 
 def mark_run_success(db: Session, item_id: str, trade_date: str, report_id: str):
     """Mark a scheduled task as successfully run."""
     item = db.query(ScheduledAnalysisDB).filter(ScheduledAnalysisDB.id == item_id).first()
     if item:
+        run_date = _parse_ymd(trade_date)
+        item.last_run_key = _period_key(item.frequency or "daily", run_date)
         item.last_run_date = trade_date
         item.last_run_status = "success"
         item.last_report_id = report_id
@@ -341,6 +577,8 @@ def mark_run_failed(db: Session, item_id: str, trade_date: str):
     """Mark a scheduled task as failed. Auto-deactivate after 3 consecutive failures."""
     item = db.query(ScheduledAnalysisDB).filter(ScheduledAnalysisDB.id == item_id).first()
     if item:
+        run_date = _parse_ymd(trade_date)
+        item.last_run_key = _period_key(item.frequency or "daily", run_date)
         item.last_run_date = trade_date
         item.last_run_status = "failed"
         item.consecutive_failures = (item.consecutive_failures or 0) + 1
@@ -371,9 +609,18 @@ def _to_dict(item: ScheduledAnalysisDB) -> dict:
     return {
         "id": item.id,
         "symbol": item.symbol,
+        "task_type": item.task_type,
+        "task_slot": item.task_slot,
+        "task_label": _slot_label(item.task_slot),
+        "frequency": item.frequency,
         "horizon": item.horizon or "short",
-        "trigger_time": item.trigger_time or "15:30",
+        "trigger_time": item.trigger_time or "20:00",
+        "day_of_week": item.day_of_week,
+        "day_of_month": item.day_of_month,
+        "prompt_mode": item.prompt_mode or "merge_global",
+        "custom_prompt": item.custom_prompt,
         "is_active": item.is_active,
+        "last_run_key": item.last_run_key,
         "last_run_date": item.last_run_date,
         "last_run_status": item.last_run_status,
         "last_report_id": item.last_report_id,

--- a/api/services/watchlist_service.py
+++ b/api/services/watchlist_service.py
@@ -18,19 +18,23 @@ def list_watchlist(db: Session, user_id: str) -> List[dict]:
         .order_by(WatchlistItemDB.sort_order, WatchlistItemDB.created_at)
         .all()
     )
-    scheduled_symbols = set(
-        row.symbol for row in
+    scheduled_rows = (
         db.query(ScheduledAnalysisDB.symbol)
         .filter(ScheduledAnalysisDB.user_id == user_id)
         .all()
     )
+    scheduled_counts: dict[str, int] = {}
+    for row in scheduled_rows:
+        symbol = row.symbol
+        scheduled_counts[symbol] = scheduled_counts.get(symbol, 0) + 1
     return [
         {
             "id": item.id,
             "symbol": item.symbol,
             "sort_order": item.sort_order,
             "created_at": item.created_at.isoformat() if item.created_at else None,
-            "has_scheduled": item.symbol in scheduled_symbols,
+            "has_scheduled": scheduled_counts.get(item.symbol, 0) > 0,
+            "scheduled_count": scheduled_counts.get(item.symbol, 0),
         }
         for item in items
     ]

--- a/frontend/src/components/ChatCopilotPanel.tsx
+++ b/frontend/src/components/ChatCopilotPanel.tsx
@@ -142,6 +142,7 @@ function ReportCard({
 
 export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initialInput }: ChatCopilotPanelProps) {
     const [input, setInput] = useState(initialInput || '')
+    const [globalPrompt, setGlobalPrompt] = useState('')
     const [streaming, setStreaming] = useState(false)
     const [showConfig, setShowConfig] = useState(false)
     // Tracks agent bubbles waiting for their first token (shows "正在推理分析中..." spinner)
@@ -259,6 +260,12 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
             behavior: 'smooth',
         })
     }, [chatMessages])
+
+    useEffect(() => {
+        api.getConfig()
+            .then(cfg => setGlobalPrompt(cfg.analysis_prompt?.trim() || ''))
+            .catch(() => {})
+    }, [])
 
     const toggleAnalyst = (id: string) => {
         setSelectedAnalysts((prev) =>
@@ -625,8 +632,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
         if (!prompt || streaming) return
 
         // Inject custom analysis prompt from settings if set
-        const customPrompt = localStorage.getItem('ta-custom-prompt')?.trim() || ''
-        const fullPrompt = customPrompt ? `${prompt}\n\n[分析要求] ${customPrompt}` : prompt
+        const fullPrompt = globalPrompt ? `${prompt}\n\n[分析要求] ${globalPrompt}` : prompt
 
         setInput('')
         addChatMessage({

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -1,126 +1,114 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
     Briefcase, Plus, Trash2, TrendingUp, Activity, Search,
-    Clock, AlertTriangle, CheckCircle2, XCircle, Loader2, Timer,
-    Database, Info, ArrowRight,
+    Clock, AlertTriangle, CheckCircle2, XCircle, Loader2, Settings2, Save,
 } from 'lucide-react'
 import { api } from '@/services/api'
-import type { WatchlistItem, ScheduledAnalysis, StockSearchResult, Report, QmtImportState } from '@/types'
-import { buildQmtSyncSummary } from '@/utils/qmtSync'
+import type { WatchlistItem, ScheduledAnalysis, StockSearchResult, Report } from '@/types'
 
-const HORIZON_LABELS: Record<string, string> = { short: '短线', medium: '中线' }
-const WATCHLIST_BATCH_SPLIT_RE = /[,\s，、；;]+/
-const SCHEDULED_TEST_TOOLTIP =
-    '会立刻对当前勾选的股票批量发起最近交易日分析请求，并自动带上已导入的持仓上下文；若已开启邮箱报告，也可以顺带检查邮箱是否收到结果。不会改动原有定时设置。'
+type TaskDraft = {
+    frequency: 'daily' | 'weekly' | 'monthly'
+    trigger_time: string
+    day_of_week: number | null
+    day_of_month: number | null
+    prompt_mode: 'merge_global' | 'override_global'
+    custom_prompt: string
+}
 
-function HorizonSwitch({
-    value,
-    onChange,
-    disabled = false,
-    compact = false,
-}: {
-    value: 'short' | 'medium'
-    onChange: (horizon: 'short' | 'medium') => void
-    disabled?: boolean
-    compact?: boolean
-}) {
-    const wrapperClass = compact ? 'h-8 w-[124px]' : 'h-10 w-[144px]'
-    const knobClass = compact ? 'top-1 left-1 h-6 w-[calc(50%-4px)]' : 'top-1 left-1 h-8 w-[calc(50%-4px)]'
-    const labelClass = compact ? 'text-[11px]' : 'text-xs'
+const WINDOW_SLOTS = [
+    { task_slot: 'pre_open_0800', title: '开盘前', time: '08:00' },
+    { task_slot: 'midday_1200', title: '午间', time: '12:00' },
+    { task_slot: 'post_close_2000', title: '收盘后', time: '20:00' },
+] as const
 
-    return (
-        <div className={`relative grid ${wrapperClass} grid-cols-2 rounded-full p-1 transition-colors ${
-            disabled
-                ? 'bg-slate-200 dark:bg-slate-700'
-                : 'bg-slate-100 dark:bg-slate-700/70'
-        }`}>
-            <div
-                className={`pointer-events-none absolute ${knobClass} rounded-full bg-white shadow-sm ring-1 ring-slate-200/80 transition-transform duration-300 dark:bg-slate-900 dark:ring-slate-700 ${
-                    value === 'medium' ? 'translate-x-full' : ''
-                }`}
-            />
-            {(['short', 'medium'] as const).map(horizon => (
-                <button
-                    key={horizon}
-                    type="button"
-                    onClick={() => onChange(horizon)}
-                    disabled={disabled}
-                    className={`relative z-10 rounded-full px-3 font-medium transition-all duration-200 ${labelClass} ${
-                        value === horizon
-                            ? 'text-slate-900 dark:text-white'
-                            : 'text-slate-500 hover:text-slate-700 dark:text-slate-300 dark:hover:text-slate-100'
-                    }`}
-                >
-                    {HORIZON_LABELS[horizon]}
-                </button>
-            ))}
-        </div>
-    )
+const CUSTOM_SLOTS = [
+    { task_slot: 'custom_short', title: '自定义短线', horizonLabel: '短线', defaultTime: '20:00' },
+    { task_slot: 'custom_long', title: '自定义长期', horizonLabel: '长期', defaultTime: '20:00' },
+] as const
+
+const WEEKDAY_OPTIONS = ['周一', '周二', '周三', '周四', '周五', '周六', '周日']
+
+function createDefaultDraft(slot: string): TaskDraft {
+    const custom = CUSTOM_SLOTS.find(item => item.task_slot === slot)
+    return {
+        frequency: 'daily',
+        trigger_time: custom?.defaultTime || '20:00',
+        day_of_week: 0,
+        day_of_month: 1,
+        prompt_mode: 'merge_global',
+        custom_prompt: '',
+    }
+}
+
+function buildDraftFromTask(task?: ScheduledAnalysis): TaskDraft {
+    if (!task) return createDefaultDraft('')
+    return {
+        frequency: (task.frequency === 'weekly' || task.frequency === 'monthly' ? task.frequency : 'daily'),
+        trigger_time: task.trigger_time || '20:00',
+        day_of_week: task.day_of_week ?? 0,
+        day_of_month: task.day_of_month ?? 1,
+        prompt_mode: task.prompt_mode || 'merge_global',
+        custom_prompt: task.custom_prompt || '',
+    }
+}
+
+function slotSort(task: ScheduledAnalysis) {
+    const order = ['pre_open_0800', 'midday_1200', 'post_close_2000', 'custom_short', 'custom_long']
+    return order.indexOf(task.task_slot)
 }
 
 export default function Portfolio() {
     const [watchlist, setWatchlist] = useState<WatchlistItem[]>([])
     const [scheduled, setScheduled] = useState<ScheduledAnalysis[]>([])
     const [latestReports, setLatestReports] = useState<Record<string, Report>>({})
-    const [qmtImportState, setQmtImportState] = useState<QmtImportState | null>(null)
     const [loading, setLoading] = useState(true)
-    const [loadError, setLoadError] = useState<string | null>(null)
-    const [selectedScheduledIds, setSelectedScheduledIds] = useState<string[]>([])
-    const [batchHorizon, setBatchHorizon] = useState<'short' | 'medium'>('short')
-    const [batchTriggerTime, setBatchTriggerTime] = useState('20:00')
-    const [scheduledBatchBusyAction, setScheduledBatchBusyAction] = useState<string | null>(null)
-    const [pendingHorizonTaskIds, setPendingHorizonTaskIds] = useState<Record<string, boolean>>({})
+    const [selectedSymbol, setSelectedSymbol] = useState<string>('')
+    const [drafts, setDrafts] = useState<Record<string, TaskDraft>>({})
+    const [savingSlot, setSavingSlot] = useState<string | null>(null)
 
-    // Search state
     const [searchQuery, setSearchQuery] = useState('')
     const [searchResults, setSearchResults] = useState<StockSearchResult[]>([])
     const [searchLoading, setSearchLoading] = useState(false)
     const [showDropdown, setShowDropdown] = useState(false)
-    const [addingWatchlist, setAddingWatchlist] = useState(false)
-    const [watchlistFeedback, setWatchlistFeedback] = useState<{
-        tone: 'success' | 'warning' | 'error'
-        message: string
-        details: string[]
-    } | null>(null)
     const searchTimerRef = useRef<ReturnType<typeof setTimeout>>()
     const dropdownRef = useRef<HTMLDivElement>(null)
 
     const navigate = useNavigate()
-    const trimmedQuery = searchQuery.trim()
-    const isBatchInput = trimmedQuery.length > 0 && WATCHLIST_BATCH_SPLIT_RE.test(trimmedQuery)
-    const selectedScheduledIdSet = new Set(selectedScheduledIds)
-    const selectedScheduledCount = scheduled.filter(task => selectedScheduledIdSet.has(task.id)).length
-    const hasSelectedScheduled = selectedScheduledCount > 0
-    const allScheduledSelected = scheduled.length > 0 && selectedScheduledCount === scheduled.length
-    const isScheduledBatchBusy = scheduledBatchBusyAction !== null
-    const qmtSummary = buildQmtSyncSummary(qmtImportState)
 
     const fetchAll = async () => {
         setLoading(true)
-        setLoadError(null)
         try {
-            const overview = await api.getPortfolioOverview()
-            setWatchlist(overview.watchlist)
-            setScheduled(overview.scheduled)
-            setQmtImportState(overview.qmt_import)
+            const [wRes, sRes] = await Promise.all([api.getWatchlist(), api.getScheduled()])
+            setWatchlist(wRes.items)
+            setScheduled(sRes.items)
+            setSelectedSymbol(prev => prev || wRes.items[0]?.symbol || '')
+
             const reportMap: Record<string, Report> = {}
-            for (const report of overview.latest_reports) {
-                reportMap[report.symbol] = report
-            }
+            await Promise.all(
+                wRes.items.map(async (item) => {
+                    try {
+                        const res = await api.getReports(item.symbol, 0, 1)
+                        if (res.reports.length > 0) reportMap[item.symbol] = res.reports[0]
+                    } catch {}
+                })
+            )
             setLatestReports(reportMap)
-        } catch (error) {
-            console.error('Failed to load portfolio overview:', error)
-            setLoadError(error instanceof Error ? error.message : '加载自选与定时分析数据失败')
-        }
-        finally {
-            setLoading(false)
-        }
+        } catch {}
+        setLoading(false)
     }
 
     useEffect(() => { void fetchAll() }, [])
 
-    // Close dropdown on outside click
+    useEffect(() => {
+        if (!selectedSymbol && watchlist[0]?.symbol) {
+            setSelectedSymbol(watchlist[0].symbol)
+        }
+        if (selectedSymbol && !watchlist.some(item => item.symbol === selectedSymbol)) {
+            setSelectedSymbol(watchlist[0]?.symbol || '')
+        }
+    }, [selectedSymbol, watchlist])
+
     useEffect(() => {
         const handler = (e: MouseEvent) => {
             if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
@@ -132,93 +120,46 @@ export default function Portfolio() {
     }, [])
 
     useEffect(() => {
-        const validIds = new Set(scheduled.map(task => task.id))
-        setSelectedScheduledIds(current => current.filter(id => validIds.has(id)))
-    }, [scheduled])
-
-    useEffect(() => {
-        if (selectedScheduledIds.length !== 1) return
-        const selectedTask = scheduled.find(task => task.id === selectedScheduledIds[0])
-        if (!selectedTask) return
-        setBatchHorizon(selectedTask.horizon === 'medium' ? 'medium' : 'short')
-        setBatchTriggerTime(selectedTask.trigger_time || '20:00')
-    }, [scheduled, selectedScheduledIds])
-
-    // Debounced search
-    useEffect(() => {
         if (searchTimerRef.current) clearTimeout(searchTimerRef.current)
-        if (!trimmedQuery || isBatchInput) {
+        if (!searchQuery.trim()) {
             setSearchResults([])
             setShowDropdown(false)
-            setSearchLoading(false)
             return
         }
         setSearchLoading(true)
         searchTimerRef.current = setTimeout(async () => {
             try {
-                const res = await api.searchStocks(trimmedQuery)
+                const res = await api.searchStocks(searchQuery.trim())
                 setSearchResults(res.results)
                 setShowDropdown(true)
-            } catch (error) {
-                console.error('Failed to search stocks:', error)
-                setShowDropdown(false)
-            }
+            } catch {}
             setSearchLoading(false)
         }, 300)
-    }, [trimmedQuery, isBatchInput])
+    }, [searchQuery])
+
+    const selectedTasks = useMemo(
+        () => scheduled.filter(task => task.symbol === selectedSymbol).sort((a, b) => slotSort(a) - slotSort(b)),
+        [scheduled, selectedSymbol],
+    )
+
+    useEffect(() => {
+        const nextDrafts: Record<string, TaskDraft> = {}
+        for (const slot of [...WINDOW_SLOTS, ...CUSTOM_SLOTS]) {
+            const task = selectedTasks.find(item => item.task_slot === slot.task_slot)
+            nextDrafts[slot.task_slot] = buildDraftFromTask(task)
+        }
+        setDrafts(nextDrafts)
+    }, [selectedTasks])
 
     const addToWatchlist = async (symbol: string) => {
         try {
-            const response = await api.addToWatchlist(symbol)
-            const item = response.results.find(result => result.status === 'added')?.item
-            if (!item) {
-                throw new Error(response.results[0]?.message || '添加失败')
-            }
+            await api.addToWatchlist(symbol)
             setSearchQuery('')
             setShowDropdown(false)
-            setWatchlistFeedback({
-                tone: 'success',
-                message: `已添加 ${item.name} 到自选列表`,
-                details: [],
-            })
-            fetchAll()
+            await fetchAll()
+            setSelectedSymbol(symbol)
         } catch (e) {
             alert(e instanceof Error ? e.message : '添加失败')
-        }
-    }
-
-    const submitWatchlistInput = async () => {
-        if (!trimmedQuery) return
-        setAddingWatchlist(true)
-        setWatchlistFeedback(null)
-        try {
-            const response = await api.addToWatchlist(trimmedQuery)
-            const details = response.results
-                .filter(item => item.status !== 'added')
-                .slice(0, 6)
-                .map(item => `${item.input}：${item.message}`)
-            const tone =
-                response.summary.failed > 0 && response.summary.added === 0 && response.summary.duplicate === 0
-                    ? 'error'
-                    : response.summary.failed > 0 || response.summary.duplicate > 0
-                        ? 'warning'
-                        : 'success'
-            setWatchlistFeedback({
-                tone,
-                message: response.message,
-                details,
-            })
-            if (response.summary.added > 0) {
-                await fetchAll()
-            }
-            if (response.summary.failed === 0) {
-                setSearchQuery('')
-                setShowDropdown(false)
-            }
-        } catch (e) {
-            alert(e instanceof Error ? e.message : '批量添加失败')
-        } finally {
-            setAddingWatchlist(false)
         }
     }
 
@@ -226,210 +167,85 @@ export default function Portfolio() {
         try {
             await api.removeFromWatchlist(id)
             await fetchAll()
-        } catch (error) {
-            console.error('Failed to remove watchlist item:', error)
-            alert(error instanceof Error ? error.message : '移除自选失败')
-        }
+        } catch {}
     }
 
-    const toggleScheduled = async (symbol: string, hasScheduled: boolean) => {
+    const setDraft = (slot: string, partial: Partial<TaskDraft>) => {
+        setDrafts(prev => ({
+            ...prev,
+            [slot]: {
+                ...(prev[slot] || createDefaultDraft(slot)),
+                ...partial,
+            },
+        }))
+    }
+
+    const getTask = (slot: string) => selectedTasks.find(task => task.task_slot === slot)
+
+    const createTaskForSlot = async (task_slot: string) => {
+        if (!selectedSymbol) return
+        setSavingSlot(task_slot)
         try {
-            if (hasScheduled) {
-                const task = scheduled.find(s => s.symbol === symbol)
-                if (task) await api.deleteScheduled(task.id)
-            } else {
-                await api.createScheduled(symbol, 'short', '20:00')
-            }
-            fetchAll()
-        } catch (e) {
-            alert(e instanceof Error ? e.message : '操作失败')
-        }
-    }
-
-    const updateWatchlistScheduledFlags = (symbols: string[], hasScheduled: boolean) => {
-        if (symbols.length === 0) return
-        const symbolSet = new Set(symbols)
-        setWatchlist(current =>
-            current.map(item => (
-                symbolSet.has(item.symbol)
-                    ? { ...item, has_scheduled: hasScheduled }
-                    : item
-            ))
-        )
-    }
-
-    const mergeScheduledTask = (nextTask: ScheduledAnalysis) => {
-        setScheduled(current =>
-            current.map(task => (task.id === nextTask.id ? { ...task, ...nextTask } : task))
-        )
-    }
-
-    const mergeScheduledTasks = (nextTasks: ScheduledAnalysis[]) => {
-        const taskMap = new Map(nextTasks.map(task => [task.id, task]))
-        setScheduled(current =>
-            current.map(task => {
-                const nextTask = taskMap.get(task.id)
-                return nextTask ? { ...task, ...nextTask } : task
+            const draft = drafts[task_slot] || createDefaultDraft(task_slot)
+            const isWindow = WINDOW_SLOTS.some(item => item.task_slot === task_slot)
+            await api.createScheduled({
+                symbol: selectedSymbol,
+                task_type: isWindow ? 'market_window' : 'custom_recurring',
+                task_slot,
+                frequency: isWindow ? 'trading_day' : draft.frequency,
+                trigger_time: isWindow ? undefined : draft.trigger_time,
+                day_of_week: draft.frequency === 'weekly' ? draft.day_of_week : null,
+                day_of_month: draft.frequency === 'monthly' ? draft.day_of_month : null,
+                prompt_mode: draft.prompt_mode,
+                custom_prompt: draft.custom_prompt,
             })
-        )
-    }
-
-    const removeScheduledTasksFromState = (itemIds: string[]) => {
-        if (itemIds.length === 0) return
-        const itemIdSet = new Set(itemIds)
-        const removedSymbols = scheduled
-            .filter(task => itemIdSet.has(task.id))
-            .map(task => task.symbol)
-
-        setScheduled(current => current.filter(task => !itemIdSet.has(task.id)))
-        setSelectedScheduledIds(current => current.filter(id => !itemIdSet.has(id)))
-        updateWatchlistScheduledFlags(removedSymbols, false)
-    }
-
-    const toggleScheduledSelection = (taskId: string) => {
-        setSelectedScheduledIds(current => (
-            current.includes(taskId)
-                ? current.filter(id => id !== taskId)
-                : [...current, taskId]
-        ))
-    }
-
-    const toggleSelectAllScheduled = () => {
-        setSelectedScheduledIds(current => (
-            current.length === scheduled.length
-                ? []
-                : scheduled.map(task => task.id)
-        ))
-    }
-
-    const updateScheduledHorizon = async (id: string, horizon: string) => {
-        const previousTask = scheduled.find(task => task.id === id)
-        if (!previousTask || previousTask.horizon === horizon) return
-
-        setPendingHorizonTaskIds(current => ({ ...current, [id]: true }))
-        mergeScheduledTask({ ...previousTask, horizon })
-        try {
-            const updatedTask = await api.updateScheduled(id, { horizon })
-            mergeScheduledTask(updatedTask)
+            await fetchAll()
         } catch (e) {
-            mergeScheduledTask(previousTask)
-            alert(e instanceof Error ? e.message : '切换分析周期失败')
+            alert(e instanceof Error ? e.message : '创建定时任务失败')
         } finally {
-            setPendingHorizonTaskIds(current => {
-                const next = { ...current }
-                delete next[id]
-                return next
+            setSavingSlot(null)
+        }
+    }
+
+    const saveTaskForSlot = async (task: ScheduledAnalysis) => {
+        setSavingSlot(task.task_slot)
+        try {
+            const draft = drafts[task.task_slot] || buildDraftFromTask(task)
+            await api.updateScheduled(task.id, {
+                frequency: task.task_type === 'custom_recurring' ? draft.frequency : undefined,
+                trigger_time: task.task_type === 'custom_recurring' ? draft.trigger_time : undefined,
+                day_of_week: draft.frequency === 'weekly' ? draft.day_of_week : null,
+                day_of_month: draft.frequency === 'monthly' ? draft.day_of_month : null,
+                prompt_mode: draft.prompt_mode,
+                custom_prompt: draft.custom_prompt,
             })
-        }
-    }
-
-    const updateScheduledTime = async (id: string, trigger_time: string) => {
-        const previousTask = scheduled.find(task => task.id === id)
-        if (!previousTask || previousTask.trigger_time === trigger_time) return
-
-        mergeScheduledTask({ ...previousTask, trigger_time })
-        try {
-            const updatedTask = await api.updateScheduled(id, { trigger_time })
-            mergeScheduledTask(updatedTask)
+            await fetchAll()
         } catch (e) {
-            mergeScheduledTask(previousTask)
-            alert(e instanceof Error ? e.message : '时间设置失败（需在交易时段外）')
-        }
-    }
-
-    const toggleScheduledActive = async (id: string, active: boolean) => {
-        const previousTask = scheduled.find(task => task.id === id)
-        if (!previousTask || previousTask.is_active === active) return
-
-        mergeScheduledTask({ ...previousTask, is_active: active })
-        try {
-            const updatedTask = await api.updateScheduled(id, { is_active: active })
-            mergeScheduledTask(updatedTask)
-        } catch (e) {
-            mergeScheduledTask(previousTask)
-            alert(e instanceof Error ? e.message : '状态切换失败')
-        }
-    }
-
-    const deleteScheduledTask = async (id: string) => {
-        const targetTask = scheduled.find(task => task.id === id)
-        if (!targetTask) return
-        try {
-            await api.deleteScheduled(id)
-            removeScheduledTasksFromState([id])
-        } catch (e) {
-            alert(e instanceof Error ? e.message : '删除失败')
-        }
-    }
-
-    const applyBatchScheduledUpdate = async (
-        actionKey: string,
-        updates: { is_active?: boolean; horizon?: string; trigger_time?: string },
-        errorMessage: string,
-    ) => {
-        const selectedTasks = scheduled.filter(task => selectedScheduledIdSet.has(task.id))
-        if (selectedTasks.length === 0) {
-            alert('请先勾选要批量设置的定时任务')
-            return
-        }
-
-        setScheduledBatchBusyAction(actionKey)
-        mergeScheduledTasks(selectedTasks.map(task => ({ ...task, ...updates })))
-        try {
-            const result = await api.updateScheduledBatch(
-                selectedTasks.map(task => task.id),
-                updates,
-            )
-            mergeScheduledTasks(result.items)
-        } catch (e) {
-            mergeScheduledTasks(selectedTasks)
-            alert(e instanceof Error ? e.message : errorMessage)
+            alert(e instanceof Error ? e.message : '保存失败')
         } finally {
-            setScheduledBatchBusyAction(null)
+            setSavingSlot(null)
         }
     }
 
-    const applyBatchScheduledDelete = async () => {
-        const selectedTasks = scheduled.filter(task => selectedScheduledIdSet.has(task.id))
-        if (selectedTasks.length === 0) {
-            alert('请先勾选要批量删除的定时任务')
-            return
-        }
-        if (!confirm(`确定删除选中的 ${selectedTasks.length} 个定时任务吗？`)) return
-
-        setScheduledBatchBusyAction('delete')
+    const toggleTaskActive = async (task: ScheduledAnalysis) => {
+        setSavingSlot(task.task_slot)
         try {
-            const result = await api.deleteScheduledBatch(selectedTasks.map(task => task.id))
-            removeScheduledTasksFromState(result.deleted_ids)
-            if (result.missing_ids.length > 0) {
-                await fetchAll()
-            }
-        } catch (e) {
-            alert(e instanceof Error ? e.message : '批量删除失败')
-        } finally {
-            setScheduledBatchBusyAction(null)
+            await api.updateScheduled(task.id, { is_active: !task.is_active })
+            await fetchAll()
+        } catch {}
+        finally {
+            setSavingSlot(null)
         }
     }
 
-    const triggerScheduledTest = async () => {
-        const selectedTasks = scheduled.filter(task => selectedScheduledIdSet.has(task.id))
-        if (selectedTasks.length === 0) {
-            alert('请先勾选要测试的定时任务')
-            return
-        }
-
-        setScheduledBatchBusyAction('trigger-test')
+    const deleteTask = async (task: ScheduledAnalysis) => {
+        setSavingSlot(task.task_slot)
         try {
-            const result = await api.triggerScheduledBatch(selectedTasks.map(task => task.id))
-            const summaryText = result.summary.with_position_context > 0
-                ? `已触发 ${result.summary.total} 个分析请求，其中 ${result.summary.with_position_context} 个已带入持仓上下文。`
-                : `已触发 ${result.summary.total} 个分析请求。`
-            alert(summaryText)
-            navigate('/reports')
-        } catch (e) {
-            alert(e instanceof Error ? e.message : '测试触发失败')
-        } finally {
-            setScheduledBatchBusyAction(null)
+            await api.deleteScheduled(task.id)
+            await fetchAll()
+        } catch {}
+        finally {
+            setSavingSlot(null)
         }
     }
 
@@ -443,136 +259,33 @@ export default function Portfolio() {
 
     return (
         <div className="space-y-6">
-            {loadError && (
-                <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-600 dark:border-rose-900/50 dark:bg-rose-950/30 dark:text-rose-300">
-                    {loadError}
-                </div>
-            )}
             <div>
                 <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">自选 & 定时分析</h1>
-                <p className="text-slate-500 dark:text-slate-400 mt-1">先同步 QMT 持仓，再为关注标的创建每日自动分析任务</p>
+                <p className="text-slate-500 dark:text-slate-400 mt-1">每只股票固定支持 3 个交易日窗口任务和 2 个自定义循环任务</p>
             </div>
 
-            <div className="grid grid-cols-1 gap-6">
-                <div className="card space-y-4">
-                    <div className="flex items-center gap-2">
-                        <Database className="w-5 h-5 text-emerald-500" />
-                        <h2 className="font-semibold text-slate-900 dark:text-slate-100">1. 一键同步 QMT 持仓</h2>
-                    </div>
-                    <p className="text-sm text-slate-500 dark:text-slate-400">
-                        QMT 同步入口已经移动到设置页。这里保留当前同步状态，方便确认持仓是否已经导入成功。
-                    </p>
-                    <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-slate-50/80 dark:bg-slate-900/40 p-4 space-y-3">
-                        <div>
-                            <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{qmtSummary.title}</p>
-                            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{qmtSummary.detail}</p>
-                        </div>
-                        <div className="flex flex-wrap gap-3">
-                            <button
-                                type="button"
-                                onClick={() => navigate('/settings')}
-                                className="btn-primary inline-flex items-center gap-2"
-                            >
-                                去设置配置
-                                <ArrowRight className="w-4 h-4" />
-                            </button>
-                            <div className="text-xs text-slate-500 dark:text-slate-400 self-center">
-                                需要修改账号、重新同步或清空 QMT 持仓时，也请前往设置页操作。
-                            </div>
-                        </div>
-                    </div>
-                    {qmtImportState && (
-                        <div className="rounded-2xl border border-slate-200 dark:border-slate-700 bg-slate-50/80 dark:bg-slate-900/40 p-4 space-y-2 text-sm">
-                            <div className="flex flex-wrap gap-3 text-slate-600 dark:text-slate-300">
-                                <span>持仓 {qmtImportState.summary.positions} 只</span>
-                                <span>{qmtImportState.last_synced_at ? `最近同步 ${qmtImportState.last_synced_at.slice(0, 19).replace('T', ' ')}` : '尚未同步'}</span>
-                            </div>
-                            {!!qmtImportState.scheduled_sync && (
-                                <div className="flex flex-wrap gap-3 text-xs text-indigo-600 dark:text-indigo-300">
-                                    <span>新增定时任务 {qmtImportState.scheduled_sync.created.length} 只</span>
-                                    <span>已存在 {qmtImportState.scheduled_sync.existing.length} 只</span>
-                                    {qmtImportState.scheduled_sync.skipped_limit.length > 0 && (
-                                        <span>超出上限未加入 {qmtImportState.scheduled_sync.skipped_limit.length} 只</span>
-                                    )}
-                                </div>
-                            )}
-                            <div className="max-h-64 overflow-y-auto pr-1 space-y-2">
-                                {qmtImportState.positions.map(item => (
-                                    <div
-                                        key={item.symbol}
-                                        className="flex flex-wrap gap-3 rounded-xl border border-slate-200/80 dark:border-slate-700/80 bg-white/80 dark:bg-slate-950/30 px-3 py-2 text-xs text-slate-500 dark:text-slate-400"
-                                    >
-                                        <span className="font-medium text-slate-700 dark:text-slate-200">{item.name}</span>
-                                        <span>{item.symbol}</span>
-                                        <span>持仓 {item.current_position ?? '-'}</span>
-                                        <span>成本 {item.average_cost ?? '-'}</span>
-                                        <span>可用 {item.available_position ?? '-'}</span>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    )}
-                </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                {/* Left: Watchlist */}
+            <div className="grid grid-cols-1 lg:grid-cols-[1.05fr,1.35fr] gap-6">
                 <div className="space-y-4">
-                    {/* Stock search */}
                     <div className="card space-y-3">
                         <div className="flex items-center gap-2">
                             <Plus className="w-5 h-5 text-blue-500" />
                             <h2 className="font-semibold text-slate-900 dark:text-slate-100">添加自选</h2>
                         </div>
-                        <div className="space-y-3" ref={dropdownRef}>
+                        <div className="relative" ref={dropdownRef}>
                             <div className="relative">
-                                <Search className="absolute left-3 top-4 w-4 h-4 text-slate-400" />
-                                <textarea
+                                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                                <input
                                     value={searchQuery}
                                     onChange={e => setSearchQuery(e.target.value)}
-                                    onFocus={() => searchResults.length > 0 && !isBatchInput && setShowDropdown(true)}
-                                    placeholder="支持单个搜索，也支持批量粘贴：600519 300750.SZ，贵州茅台 宁德时代"
-                                    className="input pl-9 pr-9 w-full min-h-[104px] resize-y"
+                                    onFocus={() => searchResults.length > 0 && setShowDropdown(true)}
+                                    placeholder="搜索代码或名称，如 300750 或 宁德时代"
+                                    className="input pl-9 w-full"
+                                    maxLength={20}
                                 />
-                                {searchLoading && <Loader2 className="absolute right-3 top-4 w-4 h-4 animate-spin text-slate-400" />}
+                                {searchLoading && <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-slate-400" />}
                             </div>
-                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                                <p className="text-xs text-slate-500 dark:text-slate-400">
-                                    输入单个标的时可搜索并点选；批量导入支持逗号、空格或换行分隔，且每项需为完整代码或完整名称。
-                                </p>
-                                <button
-                                    type="button"
-                                    onClick={submitWatchlistInput}
-                                    disabled={!trimmedQuery || addingWatchlist}
-                                    className="btn-primary inline-flex items-center justify-center gap-2 whitespace-nowrap"
-                                >
-                                    {addingWatchlist ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-                                    {isBatchInput ? '批量添加' : '添加自选'}
-                                </button>
-                            </div>
-
-                            {watchlistFeedback && (
-                                <div className={`rounded-xl border px-3 py-3 text-sm ${
-                                    watchlistFeedback.tone === 'success'
-                                        ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-300'
-                                        : watchlistFeedback.tone === 'warning'
-                                            ? 'border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-500/20 dark:bg-amber-500/10 dark:text-amber-300'
-                                            : 'border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-500/20 dark:bg-rose-500/10 dark:text-rose-300'
-                                }`}>
-                                    <div>{watchlistFeedback.message}</div>
-                                    {watchlistFeedback.details.length > 0 && (
-                                        <div className="mt-2 space-y-1 text-xs opacity-90">
-                                            {watchlistFeedback.details.map(detail => (
-                                                <div key={detail}>{detail}</div>
-                                            ))}
-                                        </div>
-                                    )}
-                                </div>
-                            )}
-
-                            {/* Search dropdown */}
                             {showDropdown && searchResults.length > 0 && (
-                                <div className="border border-slate-200 dark:border-slate-700 rounded-lg bg-white dark:bg-slate-800 shadow-lg max-h-60 overflow-y-auto">
+                                <div className="absolute z-50 w-full mt-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
                                     {searchResults.map(r => (
                                         <button
                                             key={r.symbol}
@@ -589,7 +302,6 @@ export default function Portfolio() {
                         </div>
                     </div>
 
-                    {/* Watchlist */}
                     <div className="card">
                         <div className="flex items-center gap-2 mb-4">
                             <Briefcase className="w-5 h-5 text-purple-500" />
@@ -600,51 +312,45 @@ export default function Portfolio() {
                             <div className="text-center py-10">
                                 <Briefcase className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
                                 <p className="text-slate-500 dark:text-slate-400">还没有关注的股票</p>
-                                <p className="text-sm text-slate-400 dark:text-slate-500 mt-1">搜索代码或名称添加</p>
                             </div>
                         ) : (
                             <div className="divide-y divide-slate-100 dark:divide-slate-700">
                                 {watchlist.map(item => {
                                     const report = latestReports[item.symbol]
+                                    const selected = selectedSymbol === item.symbol
                                     return (
-                                        <div key={item.id} className="flex items-center gap-3 py-3">
-                                            <div className="w-9 h-9 rounded-lg bg-blue-100 dark:bg-blue-500/10 flex items-center justify-center shrink-0">
+                                        <div
+                                            key={item.id}
+                                            onClick={() => setSelectedSymbol(item.symbol)}
+                                            className={`w-full flex items-center gap-3 py-3 text-left transition-colors ${selected ? 'bg-blue-50/70 dark:bg-blue-500/10' : 'hover:bg-slate-50 dark:hover:bg-slate-800/40'}`}
+                                        >
+                                            <div className="w-9 h-9 rounded-lg bg-blue-100 dark:bg-blue-500/10 flex items-center justify-center shrink-0 ml-2">
                                                 <TrendingUp className="w-4 h-4 text-blue-600 dark:text-blue-400" />
                                             </div>
                                             <div className="flex-1 min-w-0">
                                                 <p className="font-medium text-slate-900 dark:text-slate-100 text-sm">{item.name}</p>
                                                 <p className="text-xs text-slate-400">{item.symbol}</p>
-                                                {report && (
-                                                    <p className="text-xs text-slate-400 mt-0.5">
-                                                        最近：{report.trade_date} · {report.direction || report.decision || '—'}
-                                                    </p>
-                                                )}
+                                                <p className="text-xs text-slate-400 mt-0.5">
+                                                    定时任务：{item.scheduled_count || 0}/5
+                                                    {report && ` · 最近：${report.trade_date} · ${report.direction || report.decision || '—'}`}
+                                                </p>
                                             </div>
-                                            {/* Schedule toggle */}
                                             <button
-                                                onClick={() => toggleScheduled(item.symbol, item.has_scheduled)}
-                                                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg transition-colors ${
-                                                    item.has_scheduled
-                                                        ? 'bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-100'
-                                                        : 'bg-slate-100 dark:bg-slate-700 text-slate-500 hover:bg-slate-200 dark:hover:bg-slate-600'
-                                                }`}
-                                                title={item.has_scheduled ? '已开启定时分析' : '开启定时分析'}
-                                            >
-                                                <Timer className="w-3 h-3" />
-                                                {item.has_scheduled ? '定时' : '定时'}
-                                            </button>
-                                            {/* Analyze */}
-                                            <button
-                                                onClick={() => navigate(`/analysis?symbol=${item.symbol}`)}
+                                                onClick={(e) => {
+                                                    e.stopPropagation()
+                                                    navigate(`/analysis?symbol=${item.symbol}`)
+                                                }}
                                                 className="flex items-center gap-1 px-2 py-1 text-xs rounded-lg bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-blue-500/20 transition-colors"
                                             >
                                                 <Activity className="w-3 h-3" />
                                                 分析
                                             </button>
-                                            {/* Delete */}
                                             <button
-                                                onClick={() => removeFromWatchlist(item.id)}
-                                                className="p-1.5 text-slate-400 hover:text-red-500 transition-colors"
+                                                onClick={(e) => {
+                                                    e.stopPropagation()
+                                                    removeFromWatchlist(item.id)
+                                                }}
+                                                className="p-1.5 text-slate-400 hover:text-red-500 transition-colors mr-2"
                                             >
                                                 <Trash2 className="w-3.5 h-3.5" />
                                             </button>
@@ -656,266 +362,248 @@ export default function Portfolio() {
                     </div>
                 </div>
 
-                {/* Right: Scheduled Analysis */}
-                <div className="card">
-                    <div className="flex items-center gap-2 mb-4">
-                        <Clock className="w-5 h-5 text-emerald-500" />
-                        <h2 className="font-semibold text-slate-900 dark:text-slate-100">2. 创建定时分析 ({scheduled.length}/10)</h2>
+                <div className="space-y-4">
+                    <div className="card">
+                        <div className="flex items-center gap-2 mb-2">
+                            <Settings2 className="w-5 h-5 text-emerald-500" />
+                            <h2 className="font-semibold text-slate-900 dark:text-slate-100">定时任务管理</h2>
+                        </div>
+                        {selectedSymbol ? (
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                                当前股票：<span className="font-medium text-slate-700 dark:text-slate-200">{watchlist.find(item => item.symbol === selectedSymbol)?.name || selectedSymbol}</span>
+                                <span className="ml-2 text-xs text-slate-400">{selectedSymbol}</span>
+                            </p>
+                        ) : (
+                            <p className="text-sm text-slate-400">请先在左侧选择一只股票。</p>
+                        )}
                     </div>
-                    <p className="text-xs text-slate-400 mb-4">每个交易日在设定时间自动执行（允许 20:00~次日 08:00）</p>
 
-                    {scheduled.length > 0 && (
-                        <div className="mb-4 rounded-2xl border border-slate-200/80 bg-slate-50/80 p-4 dark:border-slate-700 dark:bg-slate-800/50">
-                            <div className="flex flex-wrap items-center gap-3">
-                                <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
-                                    <input
-                                        type="checkbox"
-                                        checked={allScheduledSelected}
-                                        onChange={toggleSelectAllScheduled}
-                                        disabled={isScheduledBatchBusy}
-                                        className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                                    />
-                                    全选
-                                </label>
-                                <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:text-slate-200 dark:ring-slate-700">
-                                    已选 {selectedScheduledCount} 项
-                                </span>
-                                <button
-                                    type="button"
-                                    onClick={() => setSelectedScheduledIds([])}
-                                    disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                    className="text-xs text-slate-500 transition-colors hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-400 dark:hover:text-slate-200"
-                                >
-                                    清空选择
-                                </button>
-                            </div>
-
-                            <div className="mt-4 flex flex-wrap items-end gap-4">
-                                <div className="space-y-2">
-                                    <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-slate-400">批量周期</p>
-                                    <HorizonSwitch
-                                        value={batchHorizon}
-                                        compact={false}
-                                        disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                        onChange={horizon => {
-                                            setBatchHorizon(horizon)
-                                            void applyBatchScheduledUpdate(
-                                                `horizon-${horizon}`,
-                                                { horizon },
-                                                '批量切换分析周期失败',
-                                            )
-                                        }}
-                                    />
+                    {selectedSymbol && (
+                        <>
+                            <div className="card space-y-4">
+                                <div>
+                                    <h3 className="font-semibold text-slate-900 dark:text-slate-100">交易日窗口任务</h3>
+                                    <p className="text-xs text-slate-400 mt-1">固定为交易日 08:00、12:00、20:00，仅可启停和配置提示偏好。</p>
                                 </div>
+                                <div className="space-y-3">
+                                    {WINDOW_SLOTS.map(slot => {
+                                        const task = getTask(slot.task_slot)
+                                        const draft = drafts[slot.task_slot] || createDefaultDraft(slot.task_slot)
+                                        return (
+                                            <div key={slot.task_slot} className="rounded-xl border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-800/40">
+                                                <div className="flex items-center gap-3">
+                                                    <div className="flex-1">
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="font-medium text-slate-900 dark:text-slate-100">{slot.title}</span>
+                                                            <span className="text-xs px-2 py-0.5 rounded bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400">{slot.time}</span>
+                                                            {task && (
+                                                                <span className="text-xs px-2 py-0.5 rounded bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400">交易日窗口</span>
+                                                            )}
+                                                        </div>
+                                                        {task?.last_run_date && (
+                                                            <div className="text-xs text-slate-400 mt-1 flex items-center gap-1">
+                                                                {task.last_run_status === 'success' ? <CheckCircle2 className="w-3 h-3 text-emerald-500" /> : null}
+                                                                {task.last_run_status === 'failed' ? <XCircle className="w-3 h-3 text-red-500" /> : null}
+                                                                最近执行：{task.last_run_date}
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                    {!task ? (
+                                                        <button onClick={() => createTaskForSlot(slot.task_slot)} className="btn-primary h-9 px-3 text-sm" disabled={savingSlot === slot.task_slot}>
+                                                            {savingSlot === slot.task_slot ? <Loader2 className="w-4 h-4 animate-spin" /> : '启用'}
+                                                        </button>
+                                                    ) : (
+                                                        <div className="flex items-center gap-2">
+                                                            <button
+                                                                onClick={() => toggleTaskActive(task)}
+                                                                className={`relative w-10 h-6 rounded-full transition-colors ${task.is_active ? 'bg-emerald-500' : 'bg-slate-300 dark:bg-slate-600'}`}
+                                                            >
+                                                                <div className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${task.is_active ? 'translate-x-5' : 'translate-x-1'}`} />
+                                                            </button>
+                                                            <button onClick={() => deleteTask(task)} className="p-2 text-slate-400 hover:text-red-500">
+                                                                <Trash2 className="w-4 h-4" />
+                                                            </button>
+                                                        </div>
+                                                    )}
+                                                </div>
 
-                                <div className="space-y-2">
-                                    <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-slate-400">批量时间</p>
-                                    <div className="flex items-center gap-2">
-                                        <input
-                                            type="time"
-                                            value={batchTriggerTime}
-                                            onChange={e => setBatchTriggerTime(e.target.value)}
-                                            disabled={isScheduledBatchBusy}
-                                            className="w-[108px] rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 transition-colors dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
-                                        />
-                                        <button
-                                            type="button"
-                                            onClick={() => void applyBatchScheduledUpdate(
-                                                'time',
-                                                { trigger_time: batchTriggerTime },
-                                                '批量修改时间失败',
-                                            )}
-                                            disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                            className="rounded-xl bg-slate-900 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-                                        >
-                                            {scheduledBatchBusyAction === 'time' ? <Loader2 className="h-4 w-4 animate-spin" /> : '应用'}
-                                        </button>
-                                    </div>
-                                </div>
-
-                                <div className="ml-auto flex flex-wrap items-center gap-2">
-                                    <div className="relative">
-                                        <button
-                                            type="button"
-                                            onClick={() => void triggerScheduledTest()}
-                                            disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                            className="rounded-xl bg-sky-600 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-sky-700 disabled:cursor-not-allowed disabled:opacity-40"
-                                        >
-                                            {scheduledBatchBusyAction === 'trigger-test' ? <Loader2 className="h-4 w-4 animate-spin" /> : '测试定时任务（批量请求）'}
-                                        </button>
-                                        <div className="group absolute -right-1 -top-1">
-                                            <button
-                                                type="button"
-                                                aria-label="测试定时任务说明"
-                                                className="flex h-4 w-4 items-center justify-center rounded-full border border-sky-200 bg-white text-sky-600 shadow-sm transition-colors hover:bg-sky-50 dark:border-sky-400/30 dark:bg-slate-900 dark:text-sky-300"
-                                            >
-                                                <Info className="h-2.5 w-2.5" />
-                                            </button>
-                                            <div className="pointer-events-none absolute right-0 top-5 z-20 w-64 rounded-xl border border-slate-200 bg-white p-3 text-left text-[11px] leading-5 text-slate-600 opacity-0 shadow-xl transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
-                                                {SCHEDULED_TEST_TOOLTIP}
+                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+                                                    <select
+                                                        value={draft.prompt_mode}
+                                                        onChange={e => setDraft(slot.task_slot, { prompt_mode: e.target.value as TaskDraft['prompt_mode'] })}
+                                                        className="input w-full"
+                                                    >
+                                                        <option value="merge_global">继承全局并追加</option>
+                                                        <option value="override_global">仅用当前任务提示</option>
+                                                    </select>
+                                                    <button
+                                                        onClick={() => task ? saveTaskForSlot(task) : createTaskForSlot(slot.task_slot)}
+                                                        className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 text-sm"
+                                                        disabled={savingSlot === slot.task_slot}
+                                                    >
+                                                        <Save className="w-4 h-4" />
+                                                        保存提示偏好
+                                                    </button>
+                                                </div>
+                                                <textarea
+                                                    value={draft.custom_prompt}
+                                                    onChange={e => setDraft(slot.task_slot, { custom_prompt: e.target.value })}
+                                                    className="input w-full min-h-[88px] resize-y mt-3"
+                                                    placeholder="例如：更关注开盘情绪、资金承接和政策催化。"
+                                                />
                                             </div>
-                                        </div>
-                                    </div>
-                                    <button
-                                        type="button"
-                                        onClick={() => void applyBatchScheduledUpdate('enable', { is_active: true }, '批量启用失败')}
-                                        disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                        className="rounded-xl bg-emerald-500 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-40"
-                                    >
-                                        {scheduledBatchBusyAction === 'enable' ? <Loader2 className="h-4 w-4 animate-spin" /> : '批量启用'}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => void applyBatchScheduledUpdate('disable', { is_active: false }, '批量停用失败')}
-                                        disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                        className="rounded-xl bg-amber-500 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-40"
-                                    >
-                                        {scheduledBatchBusyAction === 'disable' ? <Loader2 className="h-4 w-4 animate-spin" /> : '批量停用'}
-                                    </button>
-                                    <button
-                                        type="button"
-                                        onClick={() => void applyBatchScheduledDelete()}
-                                        disabled={!hasSelectedScheduled || isScheduledBatchBusy}
-                                        className="rounded-xl bg-rose-500 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-rose-600 disabled:cursor-not-allowed disabled:opacity-40"
-                                    >
-                                        {scheduledBatchBusyAction === 'delete' ? <Loader2 className="h-4 w-4 animate-spin" /> : '批量删除'}
-                                    </button>
+                                        )
+                                    })}
                                 </div>
                             </div>
 
-                            {!hasSelectedScheduled && (
-                                <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
-                                    勾选任务后，可以一键批量设置短线/中线、运行时间、启停状态、测试最近分析或删除。
-                                </p>
-                            )}
-                        </div>
-                    )}
-
-                    {scheduled.length === 0 ? (
-                        <div className="text-center py-10">
-                            <Clock className="w-12 h-12 text-slate-300 dark:text-slate-600 mx-auto mb-3" />
-                            <p className="text-slate-500 dark:text-slate-400">暂无定时任务</p>
-                            <p className="text-sm text-slate-400 dark:text-slate-500 mt-1">在自选列表中点击"定时"开启</p>
-                        </div>
-                    ) : (
-                        <div className="space-y-3">
-                            {scheduled.map(task => (
-                                <div
-                                    key={task.id}
-                                    className={`rounded-xl border p-3 transition-all ${
-                                        selectedScheduledIdSet.has(task.id)
-                                            ? 'border-blue-300 bg-blue-50/60 ring-2 ring-blue-200/70 dark:border-blue-500/40 dark:bg-blue-500/10 dark:ring-blue-500/20'
-                                            : !task.is_active
-                                            ? 'border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/30 opacity-60'
-                                            : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800/60'
-                                    }`}
-                                >
-                                    <div className="flex items-center gap-3">
-                                        <input
-                                            type="checkbox"
-                                            checked={selectedScheduledIdSet.has(task.id)}
-                                            onChange={() => toggleScheduledSelection(task.id)}
-                                            disabled={isScheduledBatchBusy}
-                                            className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                                        />
-
-                                        <div className="flex-1 min-w-0">
-                                            <div className="flex items-center gap-2">
-                                                <p className="font-medium text-sm text-slate-900 dark:text-slate-100">{task.name}</p>
-                                                <span className="text-xs text-slate-400">{task.symbol}</span>
-                                            </div>
-                                            <div className="flex items-center gap-2 mt-1 flex-wrap">
-                                                {/* Horizon badge */}
-                                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400">
-                                                    {HORIZON_LABELS[task.horizon] || task.horizon}
-                                                </span>
-                                                {/* Trigger time */}
-                                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex items-center gap-0.5">
-                                                    <Clock className="w-2.5 h-2.5" />
-                                                    {task.trigger_time}
-                                                </span>
-                                                {/* Last run status */}
-                                                {task.last_run_date && (
-                                                    <span className="text-[10px] text-slate-400 flex items-center gap-0.5">
-                                                        {task.last_run_status === 'success' ? (
-                                                            <CheckCircle2 className="w-3 h-3 text-emerald-500" />
-                                                        ) : task.last_run_status === 'failed' ? (
-                                                            <XCircle className="w-3 h-3 text-red-500" />
-                                                        ) : null}
-                                                        {task.last_run_date}
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {task.consecutive_failures >= 3 && (
-                                                <div className="flex items-center gap-1 mt-1.5 text-[10px] text-amber-600 dark:text-amber-400">
-                                                    <AlertTriangle className="w-3 h-3" />
-                                                    连续失败 {task.consecutive_failures} 次，已自动停用
-                                                </div>
-                                            )}
-                                            {task.has_imported_context && (
-                                                <div className="flex items-center gap-1 mt-1.5 text-[10px] text-indigo-600 dark:text-indigo-300 flex-wrap">
-                                                    <Database className="w-3 h-3" />
-                                                    <span>已带入持仓上下文</span>
-                                                    {task.imported_current_position != null && <span>持仓 {task.imported_current_position}</span>}
-                                                    {task.imported_average_cost != null && <span>成本 {task.imported_average_cost}</span>}
-                                                    {(task.imported_trade_points_count || 0) > 0 && <span>买卖点 {task.imported_trade_points_count}</span>}
-                                                </div>
-                                            )}
-                                        </div>
-
-                                        {/* Horizon switch */}
-                                        <HorizonSwitch
-                                            value={task.horizon === 'medium' ? 'medium' : 'short'}
-                                            compact
-                                            disabled={Boolean(pendingHorizonTaskIds[task.id]) || isScheduledBatchBusy}
-                                            onChange={horizon => updateScheduledHorizon(task.id, horizon)}
-                                        />
-
-                                        {/* Time picker */}
-                                        <input
-                                            type="time"
-                                            value={task.trigger_time}
-                                            onChange={e => updateScheduledTime(task.id, e.target.value)}
-                                            disabled={isScheduledBatchBusy}
-                                            className="w-[90px] text-sm px-2 py-1 rounded-lg border border-slate-300 dark:border-slate-600 bg-transparent text-slate-700 dark:text-slate-200"
-                                        />
-
-                                        {/* Active toggle */}
-                                        <button
-                                            type="button"
-                                            onClick={() => toggleScheduledActive(task.id, !task.is_active)}
-                                            disabled={isScheduledBatchBusy}
-                                            className={`relative w-9 h-5 rounded-full transition-colors shrink-0 ${
-                                                task.is_active ? 'bg-emerald-500' : 'bg-slate-300 dark:bg-slate-600'
-                                            }`}
-                                        >
-                                            <div className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
-                                                task.is_active ? 'translate-x-4' : 'translate-x-0.5'
-                                            }`} />
-                                        </button>
-
-                                        {/* Delete */}
-                                        <button
-                                            type="button"
-                                            onClick={() => deleteScheduledTask(task.id)}
-                                            disabled={isScheduledBatchBusy}
-                                            className="p-1.5 text-slate-400 hover:text-red-500 transition-colors shrink-0"
-                                        >
-                                            <Trash2 className="w-3.5 h-3.5" />
-                                        </button>
-                                    </div>
-
-                                    {task.last_report_id && task.last_run_status === 'success' && (
-                                        <button
-                                            onClick={() => navigate(`/reports?report=${task.last_report_id}`)}
-                                            className="mt-2 text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
-                                        >
-                                            查看最近报告 →
-                                        </button>
-                                    )}
+                            <div className="card space-y-4">
+                                <div>
+                                    <h3 className="font-semibold text-slate-900 dark:text-slate-100">自定义循环任务</h3>
+                                    <p className="text-xs text-slate-400 mt-1">固定为短线、长期各一个任务位，可配置时间、周期和偏好提示。</p>
                                 </div>
-                            ))}
-                        </div>
+                                <div className="space-y-3">
+                                    {CUSTOM_SLOTS.map(slot => {
+                                        const task = getTask(slot.task_slot)
+                                        const draft = drafts[slot.task_slot] || createDefaultDraft(slot.task_slot)
+                                        return (
+                                            <div key={slot.task_slot} className="rounded-xl border border-slate-200 dark:border-slate-700 p-4 bg-white dark:bg-slate-800/40">
+                                                <div className="flex items-center gap-3">
+                                                    <div className="flex-1">
+                                                        <div className="flex items-center gap-2 flex-wrap">
+                                                            <span className="font-medium text-slate-900 dark:text-slate-100">{slot.title}</span>
+                                                            <span className="text-xs px-2 py-0.5 rounded bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400">{slot.horizonLabel}</span>
+                                                            {task && <span className="text-xs px-2 py-0.5 rounded bg-amber-50 dark:bg-amber-500/10 text-amber-600 dark:text-amber-400">{task.frequency}</span>}
+                                                        </div>
+                                                        {task?.consecutive_failures >= 3 && (
+                                                            <div className="flex items-center gap-1 mt-1.5 text-[10px] text-amber-600 dark:text-amber-400">
+                                                                <AlertTriangle className="w-3 h-3" />
+                                                                连续失败 {task.consecutive_failures} 次，已自动停用
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                    {!task ? (
+                                                        <button onClick={() => createTaskForSlot(slot.task_slot)} className="btn-primary h-9 px-3 text-sm" disabled={savingSlot === slot.task_slot}>
+                                                            {savingSlot === slot.task_slot ? <Loader2 className="w-4 h-4 animate-spin" /> : '创建'}
+                                                        </button>
+                                                    ) : (
+                                                        <div className="flex items-center gap-2">
+                                                            <button
+                                                                onClick={() => toggleTaskActive(task)}
+                                                                className={`relative w-10 h-6 rounded-full transition-colors ${task.is_active ? 'bg-emerald-500' : 'bg-slate-300 dark:bg-slate-600'}`}
+                                                            >
+                                                                <div className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow transition-transform ${task.is_active ? 'translate-x-5' : 'translate-x-1'}`} />
+                                                            </button>
+                                                            <button onClick={() => deleteTask(task)} className="p-2 text-slate-400 hover:text-red-500">
+                                                                <Trash2 className="w-4 h-4" />
+                                                            </button>
+                                                        </div>
+                                                    )}
+                                                </div>
+
+                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
+                                                    <select
+                                                        value={draft.frequency}
+                                                        onChange={e => setDraft(slot.task_slot, { frequency: e.target.value as TaskDraft['frequency'] })}
+                                                        className="input w-full"
+                                                    >
+                                                        <option value="daily">每天</option>
+                                                        <option value="weekly">每周</option>
+                                                        <option value="monthly">每月</option>
+                                                    </select>
+                                                    <input
+                                                        type="time"
+                                                        value={draft.trigger_time}
+                                                        onChange={e => setDraft(slot.task_slot, { trigger_time: e.target.value })}
+                                                        className="input w-full"
+                                                    />
+                                                    {draft.frequency === 'weekly' && (
+                                                        <select
+                                                            value={draft.day_of_week ?? 0}
+                                                            onChange={e => setDraft(slot.task_slot, { day_of_week: Number(e.target.value) })}
+                                                            className="input w-full"
+                                                        >
+                                                            {WEEKDAY_OPTIONS.map((label, idx) => (
+                                                                <option key={label} value={idx}>{label}</option>
+                                                            ))}
+                                                        </select>
+                                                    )}
+                                                    {draft.frequency === 'monthly' && (
+                                                        <input
+                                                            type="number"
+                                                            min={1}
+                                                            max={31}
+                                                            value={draft.day_of_month ?? 1}
+                                                            onChange={e => setDraft(slot.task_slot, { day_of_month: Number(e.target.value) })}
+                                                            className="input w-full"
+                                                        />
+                                                    )}
+                                                    <select
+                                                        value={draft.prompt_mode}
+                                                        onChange={e => setDraft(slot.task_slot, { prompt_mode: e.target.value as TaskDraft['prompt_mode'] })}
+                                                        className="input w-full md:col-span-2"
+                                                    >
+                                                        <option value="merge_global">继承全局并追加</option>
+                                                        <option value="override_global">仅用当前任务提示</option>
+                                                    </select>
+                                                </div>
+                                                <textarea
+                                                    value={draft.custom_prompt}
+                                                    onChange={e => setDraft(slot.task_slot, { custom_prompt: e.target.value })}
+                                                    className="input w-full min-h-[96px] resize-y mt-3"
+                                                    placeholder="例如：长期任务更关注估值安全边际、行业景气和机构持仓变化。"
+                                                />
+                                                <div className="flex items-center justify-between mt-3">
+                                                    {task?.last_report_id && task.last_run_status === 'success' ? (
+                                                        <button
+                                                            onClick={() => navigate(`/reports?report=${task.last_report_id}`)}
+                                                            className="text-xs text-blue-500 hover:text-blue-600 flex items-center gap-1"
+                                                        >
+                                                            查看最近报告 →
+                                                        </button>
+                                                    ) : <span />}
+                                                    <button
+                                                        onClick={() => task ? saveTaskForSlot(task) : createTaskForSlot(slot.task_slot)}
+                                                        className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900 text-sm"
+                                                        disabled={savingSlot === slot.task_slot}
+                                                    >
+                                                        {savingSlot === slot.task_slot ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                                                        保存任务
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        )
+                                    })}
+                                </div>
+                            </div>
+
+                            <div className="card">
+                                <div className="flex items-center gap-2 mb-3">
+                                    <Clock className="w-5 h-5 text-emerald-500" />
+                                    <h2 className="font-semibold text-slate-900 dark:text-slate-100">当前股票已创建任务 ({selectedTasks.length}/5)</h2>
+                                </div>
+                                {selectedTasks.length === 0 ? (
+                                    <p className="text-sm text-slate-400">当前股票还没有已创建的定时任务。</p>
+                                ) : (
+                                    <div className="space-y-2">
+                                        {selectedTasks.map(task => (
+                                            <div key={task.id} className="rounded-lg bg-slate-50 dark:bg-slate-800/50 px-3 py-2 flex items-center gap-3">
+                                                <div className="flex-1 min-w-0">
+                                                    <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{task.task_label}</p>
+                                                    <p className="text-xs text-slate-400">
+                                                        {task.task_type === 'market_window' ? '交易日窗口' : `自定义${task.horizon === 'medium' ? '长期' : '短线'}`} · {task.trigger_time}
+                                                        {task.frequency !== 'trading_day' ? ` · ${task.frequency}` : ''}
+                                                    </p>
+                                                </div>
+                                                <span className={`text-xs px-2 py-0.5 rounded ${task.is_active ? 'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-400' : 'bg-slate-200 text-slate-500 dark:bg-slate-700 dark:text-slate-300'}`}>
+                                                    {task.is_active ? '启用中' : '已停用'}
+                                                </span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        </>
                     )}
                 </div>
             </div>

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -129,6 +129,14 @@ function ActiveDetailStatusCard({ report }: { report: ReportDetail }) {
     )
 }
 
+const formatScheduledFrequency = (frequency?: string) => {
+    if (frequency === 'trading_day') return '交易日'
+    if (frequency === 'daily') return '每天'
+    if (frequency === 'weekly') return '每周'
+    if (frequency === 'monthly') return '每月'
+    return frequency || '-'
+}
+
 const renderStatusBadge = (report: Report) => {
     switch (report.status) {
         case 'pending':
@@ -509,6 +517,11 @@ export default function Reports() {
                 <div className="flex items-center gap-4 text-sm text-slate-500">
                     <span>分析日期：{selectedReport.trade_date}</span>
                     <span>生成时间：{selectedReport.created_at ? new Date(selectedReport.created_at).toLocaleString('zh-CN') : '-'}</span>
+                    {selectedReport.report_source === 'scheduled' && (
+                        <span className="px-2 py-0.5 rounded-full bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300">
+                            定时报告 · {formatScheduledFrequency(selectedReport.scheduled_frequency)}
+                        </span>
+                    )}
                 </div>
 
                 {/* 历史决策时间线 */}
@@ -728,6 +741,11 @@ export default function Reports() {
                                                         <p className="font-medium text-slate-900 dark:text-slate-100">{report.name || report.symbol}</p>
                                                         {report.name && report.name !== report.symbol && (
                                                             <p className="text-xs text-slate-400 dark:text-slate-500">{report.symbol}</p>
+                                                        )}
+                                                        {report.report_source === 'scheduled' && (
+                                                            <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-0.5">
+                                                                定时任务 · {formatScheduledFrequency(report.scheduled_frequency)}
+                                                            </p>
                                                         )}
                                                     </div>
                                                 </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -119,7 +119,6 @@ export default function Settings() {
                     localStorage.setItem('tradingagents-settings', JSON.stringify(s))
                 }
                 if (s.defaultAnalysts) setDefaultAnalysts(s.defaultAnalysts)
-                if (typeof s.customPrompt === 'string') setCustomPrompt(s.customPrompt)
             }
         } catch {}
     }, [])
@@ -135,6 +134,7 @@ export default function Settings() {
                 setQuickThinkLlm(cfg.quick_think_llm)
                 setMaxDebateRounds(cfg.max_debate_rounds)
                 setMaxRiskRounds(cfg.max_risk_discuss_rounds)
+                setCustomPrompt(cfg.analysis_prompt || '')
                 setHasStoredApiKey(!!cfg.has_api_key)
                 setHasStoredWebhook(!!cfg.has_wecom_webhook)
                 setStoredWebhookDisplay(cfg.wecom_webhook_display || '')
@@ -215,9 +215,7 @@ export default function Settings() {
     const persistLocalSettings = () => {
         localStorage.setItem('tradingagents-settings', JSON.stringify({
             defaultAnalysts,
-            customPrompt,
         }))
-        localStorage.setItem('ta-custom-prompt', customPrompt)
     }
 
     const buildRuntimeConfigPayload = (options?: { includeEmail?: boolean; includeWecom?: boolean }) => ({
@@ -227,6 +225,7 @@ export default function Settings() {
         quick_think_llm: quickThinkLlm,
         max_debate_rounds: maxDebateRounds,
         max_risk_discuss_rounds: maxRiskRounds,
+        analysis_prompt: customPrompt,
         api_key: llmApiKey || undefined,
         ...(options?.includeWecom ? {
             wecom_webhook_url: wecomWebhook.trim() || undefined,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -6,11 +6,11 @@ export function getBaseUrl(): string {
     if (typeof window !== 'undefined' && window.location?.origin) {
         return window.location.origin.replace(/\/$/, '')
     }
-    return 'http://localhost:8000'
+    return 'http://localhost:22222'
 }
 
 // Kept for backward compatibility
-export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:22222'
 
 function getAuthToken(): string | null {
     try {
@@ -180,13 +180,31 @@ class ApiService {
     async getPortfolioOverview(): Promise<PortfolioOverviewResponse> {
         return this.request<PortfolioOverviewResponse>('/v1/portfolio/overview')
     }
-    async createScheduled(symbol: string, horizon?: string, trigger_time?: string): Promise<ScheduledAnalysis> {
+    async createScheduled(data: {
+        symbol: string
+        task_type: 'market_window' | 'custom_recurring'
+        task_slot: string
+        frequency?: 'trading_day' | 'daily' | 'weekly' | 'monthly'
+        trigger_time?: string
+        day_of_week?: number | null
+        day_of_month?: number | null
+        prompt_mode?: 'merge_global' | 'override_global'
+        custom_prompt?: string
+    }): Promise<ScheduledAnalysis> {
         return this.request<ScheduledAnalysis>('/v1/scheduled', {
             method: 'POST',
-            body: JSON.stringify({ symbol, horizon, trigger_time }),
+            body: JSON.stringify(data),
         })
     }
-    async updateScheduled(id: string, data: { is_active?: boolean; horizon?: string; trigger_time?: string }): Promise<ScheduledAnalysis> {
+    async updateScheduled(id: string, data: {
+        is_active?: boolean
+        frequency?: 'daily' | 'weekly' | 'monthly'
+        trigger_time?: string
+        day_of_week?: number | null
+        day_of_month?: number | null
+        prompt_mode?: 'merge_global' | 'override_global'
+        custom_prompt?: string
+    }): Promise<ScheduledAnalysis> {
         return this.request<ScheduledAnalysis>('/v1/scheduled/' + id, {
             method: 'PATCH',
             body: JSON.stringify(data),
@@ -194,7 +212,15 @@ class ApiService {
     }
     async updateScheduledBatch(
         item_ids: string[],
-        data: { is_active?: boolean; horizon?: string; trigger_time?: string }
+        data: {
+            is_active?: boolean
+            frequency?: 'daily' | 'weekly' | 'monthly'
+            trigger_time?: string
+            day_of_week?: number | null
+            day_of_month?: number | null
+            prompt_mode?: 'merge_global' | 'override_global'
+            custom_prompt?: string
+        }
     ): Promise<{ items: ScheduledAnalysis[] }> {
         return this.request<{ items: ScheduledAnalysis[] }>('/v1/scheduled/batch', {
             method: 'PATCH',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -331,6 +331,11 @@ export interface Report {
     stop_loss_price?: number
     risk_items?: RiskItem[]
     key_metrics?: KeyMetric[]
+    report_source?: 'manual' | 'scheduled'
+    scheduled_task_id?: string
+    scheduled_task_slot?: string
+    scheduled_frequency?: string
+    prompt_snapshot?: string
     created_at?: string
     updated_at?: string
     waiting_ahead_count?: number | null
@@ -391,6 +396,7 @@ export interface WatchlistItem {
     sort_order: number
     created_at: string
     has_scheduled: boolean
+    scheduled_count?: number
 }
 
 export interface WatchlistBatchResult {
@@ -417,9 +423,18 @@ export interface ScheduledAnalysis {
     id: string
     symbol: string
     name: string
+    task_type: 'market_window' | 'custom_recurring'
+    task_slot: string
+    task_label: string
+    frequency: 'trading_day' | 'daily' | 'weekly' | 'monthly'
     horizon: string
     trigger_time: string
+    day_of_week?: number | null
+    day_of_month?: number | null
+    prompt_mode: 'merge_global' | 'override_global'
+    custom_prompt?: string | null
     is_active: boolean
+    last_run_key?: string | null
     last_run_date: string | null
     last_run_status: string | null
     last_report_id: string | null
@@ -565,6 +580,7 @@ export interface RuntimeConfig {
     backend_url: string
     max_debate_rounds: number
     max_risk_discuss_rounds: number
+    analysis_prompt?: string
     has_api_key?: boolean
     has_wecom_webhook?: boolean
     wecom_webhook_display?: string | null
@@ -588,6 +604,7 @@ export interface RuntimeConfigUpdate {
     backend_url?: string
     max_debate_rounds?: number
     max_risk_discuss_rounds?: number
+    analysis_prompt?: string
     api_key?: string
     wecom_webhook_url?: string
     clear_api_key?: boolean

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -174,6 +174,14 @@ class TestAnalyzeEndpoint:
         now = datetime.now(timezone.utc)
 
         with get_db_ctx() as db:
+            db.query(ImportedPortfolioPositionDB).filter(
+                ImportedPortfolioPositionDB.user_id == current_user["id"],
+                ImportedPortfolioPositionDB.source == "qmt_xtquant",
+                ImportedPortfolioPositionDB.symbol == "600519.SH",
+            ).delete()
+            db.query(QmtImportConfigDB).filter(
+                QmtImportConfigDB.user_id == current_user["id"],
+            ).delete()
             db.add(
                 QmtImportConfigDB(
                     id=uuid4().hex,
@@ -217,6 +225,14 @@ class TestAnalyzeEndpoint:
         assert user_context["average_cost"] == pytest.approx(1680.5)
         assert user_context["current_position_pct"] == pytest.approx(42.5)
         assert "QMT / xtquant 持仓同步" in (user_context.get("user_notes") or "")
+
+    def test_runtime_config_supports_analysis_prompt(self):
+        r = self.client.patch("/v1/config", headers=self.headers, json={
+            "analysis_prompt": "更关注政策催化与机构资金变化",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["current"]["analysis_prompt"] == "更关注政策催化与机构资金变化"
 
 
 class TestChatCompletionsEndpoint:

--- a/tests/test_watchlist_scheduled.py
+++ b/tests/test_watchlist_scheduled.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from api.database import Base
-from api.services import watchlist_service, scheduled_service
+from api.services import scheduled_service, watchlist_service
 
 
 @pytest.fixture
@@ -16,6 +16,27 @@ def db():
     session = Session()
     yield session
     session.close()
+
+
+def _create_window_task(db, symbol: str, slot: str):
+    return scheduled_service.create_scheduled(
+        db,
+        "user1",
+        symbol,
+        task_type="market_window",
+        task_slot=slot,
+    )
+
+
+def _create_custom_task(db, symbol: str, slot: str, **kwargs):
+    return scheduled_service.create_scheduled(
+        db,
+        "user1",
+        symbol,
+        task_type="custom_recurring",
+        task_slot=slot,
+        **kwargs,
+    )
 
 
 class TestWatchlist:
@@ -47,13 +68,15 @@ class TestWatchlist:
         assert len(watchlist_service.list_watchlist(db, "user1")) == 1
         assert len(watchlist_service.list_watchlist(db, "user2")) == 1
 
-    def test_has_scheduled_flag(self, db):
+    def test_has_scheduled_flag_and_count(self, db):
         watchlist_service.add_watchlist_item(db, "user1", "300750.SZ")
         watchlist_service.add_watchlist_item(db, "user1", "600519.SH")
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        _create_window_task(db, "300750.SZ", "pre_open_0800")
+        _create_custom_task(db, "300750.SZ", "custom_short", frequency="daily", trigger_time="20:00")
         items = watchlist_service.list_watchlist(db, "user1")
         by_symbol = {i["symbol"]: i for i in items}
         assert by_symbol["300750.SZ"]["has_scheduled"] is True
+        assert by_symbol["300750.SZ"]["scheduled_count"] == 2
         assert by_symbol["600519.SH"]["has_scheduled"] is False
 
     def test_batch_add_returns_per_item_results(self, db):
@@ -88,111 +111,106 @@ class TestWatchlist:
 
 
 class TestScheduled:
-    def test_create_and_list(self, db):
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short")
+    def test_create_market_window_task(self, db):
+        item = _create_window_task(db, "300750.SZ", "pre_open_0800")
+        assert item["task_type"] == "market_window"
+        assert item["task_slot"] == "pre_open_0800"
+        assert item["trigger_time"] == "08:00"
+        assert item["frequency"] == "trading_day"
+        assert item["horizon"] == "short"
+
+    def test_create_custom_long_maps_to_medium(self, db):
+        item = _create_custom_task(db, "300750.SZ", "custom_long", frequency="daily", trigger_time="07:30")
+        assert item["task_type"] == "custom_recurring"
+        assert item["horizon"] == "medium"
+        assert item["trigger_time"] == "07:30"
+
+    def test_duplicate_slot_rejected(self, db):
+        _create_window_task(db, "300750.SZ", "pre_open_0800")
+        with pytest.raises(ValueError, match="任务已存在"):
+            _create_window_task(db, "300750.SZ", "pre_open_0800")
+
+    def test_same_symbol_can_have_five_slots(self, db):
+        _create_window_task(db, "300750.SZ", "pre_open_0800")
+        _create_window_task(db, "300750.SZ", "midday_1200")
+        _create_window_task(db, "300750.SZ", "post_close_2000")
+        _create_custom_task(db, "300750.SZ", "custom_short", frequency="weekly", trigger_time="07:30", day_of_week=0)
+        _create_custom_task(db, "300750.SZ", "custom_long", frequency="monthly", trigger_time="20:00", day_of_month=20)
         items = scheduled_service.list_scheduled(db, "user1")
-        assert len(items) == 1
-        assert items[0]["horizon"] == "short"
-        assert items[0]["trigger_time"] == "20:00"
+        assert len(items) == 5
 
-    def test_create_with_custom_time(self, db):
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "medium", "07:30")
-        items = scheduled_service.list_scheduled(db, "user1")
-        assert items[0]["trigger_time"] == "07:30"
-        assert items[0]["horizon"] == "medium"
+    def test_reject_daytime_hours_for_custom_task(self, db):
+        with pytest.raises(ValueError, match="12:00"):
+            _create_custom_task(db, "300750.SZ", "custom_short", frequency="daily", trigger_time="10:30")
 
-    def test_reject_daytime_hours(self, db):
-        with pytest.raises(ValueError, match="20:00"):
-            scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "10:30")
-        with pytest.raises(ValueError, match="20:00"):
-            scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "15:00")
+    def test_allow_fixed_midday_boundary(self, db):
+        item = _create_window_task(db, "300750.SZ", "midday_1200")
+        assert item["trigger_time"] == "12:00"
 
-    def test_allow_boundary_times(self, db):
-        # 08:00 is the boundary, should be OK
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "08:00")
-        # 20:00 is the start, should be OK
-        scheduled_service.create_scheduled(db, "user1", "600519.SH", "short", "20:00")
-        # Midnight should be OK
-        scheduled_service.create_scheduled(db, "user1", "000001.SZ", "short", "00:30")
-
-    def test_duplicate_rejected(self, db):
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        with pytest.raises(ValueError, match="已有定时分析"):
-            scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-
-    def test_invalid_horizon(self, db):
-        with pytest.raises(ValueError, match="horizon"):
-            scheduled_service.create_scheduled(db, "user1", "300750.SZ", "long")
-
-    def test_max_limit(self, db):
-        for i in range(10):
-            scheduled_service.create_scheduled(db, "user1", f"{600000 + i}.SH")
-        with pytest.raises(ValueError, match="上限"):
-            scheduled_service.create_scheduled(db, "user1", "000001.SZ")
-
-    def test_update_horizon(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short")
-        updated = scheduled_service.update_scheduled(db, "user1", item["id"], horizon="medium")
-        assert updated["horizon"] == "medium"
-
-    def test_update_trigger_time(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        updated = scheduled_service.update_scheduled(db, "user1", item["id"], trigger_time="21:30")
-        assert updated["trigger_time"] == "21:30"
-
-    def test_batch_update_horizon_and_time(self, db):
-        first = scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "20:00")
-        second = scheduled_service.create_scheduled(db, "user1", "600519.SH", "short", "20:00")
-
-        items = scheduled_service.batch_update_scheduled(
+    def test_update_custom_schedule_fields(self, db):
+        item = _create_custom_task(db, "300750.SZ", "custom_short", frequency="daily", trigger_time="20:00")
+        updated = scheduled_service.update_scheduled(
             db,
             "user1",
-            [first["id"], second["id"]],
-            horizon="medium",
-            trigger_time="21:30",
+            item["id"],
+            frequency="weekly",
+            trigger_time="07:30",
+            day_of_week=2,
+            prompt_mode="override_global",
+            custom_prompt="更关注量价和缺口",
         )
+        assert updated["frequency"] == "weekly"
+        assert updated["day_of_week"] == 2
+        assert updated["prompt_mode"] == "override_global"
+        assert updated["custom_prompt"] == "更关注量价和缺口"
 
-        assert [item["horizon"] for item in items] == ["medium", "medium"]
-        assert [item["trigger_time"] for item in items] == ["21:30", "21:30"]
+    def test_update_market_window_only_changes_prompt_fields(self, db):
+        item = _create_window_task(db, "300750.SZ", "post_close_2000")
+        updated = scheduled_service.update_scheduled(
+            db,
+            "user1",
+            item["id"],
+            trigger_time="07:30",
+            frequency="weekly",
+            prompt_mode="override_global",
+            custom_prompt="关注龙虎榜",
+        )
+        assert updated["trigger_time"] == "20:00"
+        assert updated["frequency"] == "trading_day"
+        assert updated["prompt_mode"] == "override_global"
 
     def test_batch_update_active_resets_failures(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        item = _create_window_task(db, "300750.SZ", "post_close_2000")
         scheduled_service.mark_run_failed(db, item["id"], "2026-03-21")
-
         items = scheduled_service.batch_update_scheduled(
             db,
             "user1",
             [item["id"]],
             is_active=True,
         )
-
         assert items[0]["is_active"] is True
         assert items[0]["consecutive_failures"] == 0
 
     def test_batch_update_rejects_invalid_ids(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        item = _create_window_task(db, "300750.SZ", "post_close_2000")
         with pytest.raises(ValueError, match="失效"):
             scheduled_service.batch_update_scheduled(
                 db,
                 "user1",
                 [item["id"], "missing-id"],
-                horizon="medium",
+                is_active=False,
             )
 
-    def test_update_reject_daytime(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        with pytest.raises(ValueError, match="20:00"):
-            scheduled_service.update_scheduled(db, "user1", item["id"], trigger_time="11:00")
-
-    def test_mark_success(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        scheduled_service.mark_run_success(db, item["id"], "2026-03-21", "report-123")
+    def test_mark_success_records_last_run_key(self, db):
+        item = _create_custom_task(db, "300750.SZ", "custom_short", frequency="weekly", trigger_time="20:00", day_of_week=4)
+        scheduled_service.mark_run_success(db, item["id"], "2026-03-20", "report-123")
         items = scheduled_service.list_scheduled(db, "user1")
         assert items[0]["last_run_status"] == "success"
         assert items[0]["last_report_id"] == "report-123"
+        assert items[0]["last_run_key"] == "2026-W12"
 
     def test_mark_failed_auto_deactivate(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        item = _create_window_task(db, "300750.SZ", "post_close_2000")
         for day in range(1, 4):
             scheduled_service.mark_run_failed(db, item["id"], f"2026-03-{20 + day}")
         items = scheduled_service.list_scheduled(db, "user1")
@@ -200,49 +218,38 @@ class TestScheduled:
         assert items[0]["consecutive_failures"] == 3
 
     def test_record_manual_test_result_keeps_schedule_window_available(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        item = _create_window_task(db, "300750.SZ", "post_close_2000")
         scheduled_service.record_manual_test_result(db, item["id"], "success", "manual-report")
         items = scheduled_service.list_scheduled(db, "user1")
         assert items[0]["last_run_status"] == "success"
         assert items[0]["last_report_id"] == "manual-report"
         assert items[0]["last_run_date"] is None
 
-    def test_reactivate_resets_failures(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        scheduled_service.mark_run_failed(db, item["id"], "2026-03-21")
-        scheduled_service.update_scheduled(db, "user1", item["id"], is_active=True)
-        items = scheduled_service.list_scheduled(db, "user1")
-        assert items[0]["consecutive_failures"] == 0
+    def test_get_pending_tasks_respects_custom_frequency(self, db):
+        _create_window_task(db, "300750.SZ", "post_close_2000")
+        _create_custom_task(db, "300750.SZ", "custom_short", frequency="weekly", trigger_time="07:30", day_of_week=4)
+        tasks = scheduled_service.get_pending_tasks(db, "2026-03-20", "20:30")
+        slots = {task.task_slot for task in tasks}
+        assert "post_close_2000" in slots
+        assert "custom_short" in slots
 
-    def test_get_pending_tasks_respects_trigger_time(self, db):
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ", "short", "20:00")
-        scheduled_service.create_scheduled(db, "user1", "600519.SH", "short", "22:00")
-        # At 20:30, only the 20:00 task should be pending
-        tasks = scheduled_service.get_pending_tasks(db, "2026-03-21", "20:30")
+    def test_get_pending_skips_already_run_in_same_period(self, db):
+        item = _create_custom_task(db, "300750.SZ", "custom_short", frequency="monthly", trigger_time="20:00", day_of_month=20)
+        tasks = scheduled_service.get_pending_tasks(db, "2026-03-20", "20:30")
         assert len(tasks) == 1
-        assert tasks[0].symbol == "300750.SZ"
-        # At 22:00, both should be pending
-        tasks2 = scheduled_service.get_pending_tasks(db, "2026-03-21", "22:00")
-        assert len(tasks2) == 2
-
-    def test_get_pending_skips_already_run(self, db):
-        scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        tasks = scheduled_service.get_pending_tasks(db, "2026-03-21", "23:59")
-        scheduled_service.mark_run_success(db, tasks[0].id, "2026-03-21", "r1")
-        tasks2 = scheduled_service.get_pending_tasks(db, "2026-03-21", "23:59")
+        scheduled_service.mark_run_success(db, item["id"], "2026-03-20", "r1")
+        tasks2 = scheduled_service.get_pending_tasks(db, "2026-03-20", "20:30")
         assert len(tasks2) == 0
 
     def test_delete(self, db):
-        item = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
+        item = _create_window_task(db, "300750.SZ", "pre_open_0800")
         assert scheduled_service.delete_scheduled(db, "user1", item["id"])
         assert len(scheduled_service.list_scheduled(db, "user1")) == 0
 
     def test_batch_delete(self, db):
-        first = scheduled_service.create_scheduled(db, "user1", "300750.SZ")
-        second = scheduled_service.create_scheduled(db, "user1", "600519.SH")
-
+        first = _create_window_task(db, "300750.SZ", "pre_open_0800")
+        second = _create_window_task(db, "600519.SH", "post_close_2000")
         result = scheduled_service.batch_delete_scheduled(db, "user1", [first["id"], second["id"]])
-
         assert result["deleted_ids"] == [first["id"], second["id"]]
         assert result["missing_ids"] == []
         assert scheduled_service.list_scheduled(db, "user1") == []


### PR DESCRIPTION

**标题**
定时分析升级为 5 槽位模型，并补充定时报告元数据与提示词配置

**PR 描述**
## 变更背景

当前定时分析只支持“单只股票一个定时任务”，无法满足 A 股用户在开盘前、午间、收盘后等多个关键时段重复分析的需求；同时，定时任务也缺少股票级提示偏好和报告来源标识，不利于后续报告追踪与差异分析能力建设。

本次 PR 对定时分析进行了结构化升级，并补齐了后续能力所需的基础元数据。

## 本次改动

### 1. 定时任务升级为 5 槽位模型
每个用户、每只股票现在支持固定 5 个定时任务位：

- 交易日窗口任务 3 个
- `pre_open_0800`
- `midday_1200`
- `post_close_2000`

- 自定义循环任务 2 个
- `custom_short`
- `custom_long`

其中：

- 交易日窗口任务固定在 `08:00 / 12:00 / 20:00` 执行，仅在交易日生效
- 自定义任务支持 `daily / weekly / monthly`
- `custom_long` 在内部映射为现有的 `medium` 分析能力，前端文案展示为“长期”

### 2. 定时任务数据模型与调度逻辑重构
后端新增并接入以下核心字段：

- `task_type`
- `task_slot`
- `frequency`
- `day_of_week`
- `day_of_month`
- `prompt_mode`
- `custom_prompt`
- `last_run_key`

并将原先“同一用户同一股票唯一”的约束，调整为“同一用户同一股票同一槽位唯一”。

调度判定也从“今天是否已执行”升级为“当前周期是否已执行”，支持：

- `trading_day / daily` 按日期判定
- `weekly` 按周判定
- `monthly` 按月判定

### 3. 全局提示词后端化，并支持股票级定时偏好
将原本只保存在前端本地的全局分析提示词正式下沉到后端配置中，供手动分析和定时分析共用。

同时，定时任务新增股票级提示偏好能力，支持两种模式：

- `merge_global`：继承全局提示词并追加任务偏好
- `override_global`：仅使用该任务提示词

### 4. 定时报告补充来源元数据
为报告增加以下字段，用于标识定时来源并为后续报告差异分析做准备：

- `report_source`
- `scheduled_task_id`
- `scheduled_task_slot`
- `scheduled_frequency`
- `prompt_snapshot`

这样可以在报告列表和详情中识别：

- 是否为定时报告
- 来自哪个任务槽位
- 使用了哪种频率
- 当次执行时实际拼接的提示词快照

### 5. 前端交互改造
自选页中的定时能力从“单开关”升级为“按股票管理固定任务槽位”，支持：

- 管理 3 个交易日窗口任务
- 管理 2 个自定义循环任务
- 配置频率、时间、周/月参数
- 配置提示词继承模式与股票级偏好
- 查看任务启停状态、最近执行状态与最近报告入口

设置页中的“自定义分析提示”也改为通过后端配置保存，不再只依赖本地存储。

## 兼容性说明

为兼容现有调用链和测试，本次保留了部分旧接口用法的兼容映射：

- 旧的 `symbol + horizon + trigger_time` 创建方式会自动映射到新的自定义槽位模型
- 批量更新接口仍兼容原有字段输入方式

## 测试情况

已通过以下测试：

```bash
uv run pytest -s tests/test_watchlist_scheduled.py tests/test_api_smoke.py tests/test_config_fallback.py
```

结果：

```bash
66 passed
```

## 后续计划

本次 PR 只补齐定时分析升级和报告元数据，不包含完整的“报告差异分析”功能实现。下一阶段将在此基础上继续推进：

- 同一股票多份报告差异分析
- 对“减持 -> 增持”等结论翻转进行差异归因
- 为报告回调能力预留进一步扩展



以下 是提供给AI阅读的任务计划书：

`# 定时分析 5 任务模型任务计划

## 摘要
本轮按新的双类型模型改造定时分析：

- 每个用户每只股票最多 5 个定时任务
- 分成两类：
  - `交易日窗口任务`：固定 3 个，分别是 `08:00`、`12:00`、`20:00`，仅在交易日生效
  - `自定义循环任务`：固定 2 个，分别对应“短线”和“长期”各 1 个，时间可自定义，支持 `每天 / 每周 / 每月`
- “长期”实现上默认映射到现有 `medium` 能力，前端文案显示“长期”
- 定时任务支持股票级提示偏好，并与设置中的全局提示词集成
- 定时生成的报告写入来源标识、任务关联和提示词快照，为下一阶段报告差异分析打基础

## 关键实现变化
### 1. 定时任务模型重构
- 将定时任务从“自由单条记录”改为“按任务类别受限的结构化模型”
- 每只股票允许的任务集合固定为：
  - 交易日窗口任务 3 个：`pre_open_0800`、`midday_1200`、`post_close_2000`
  - 自定义循环任务 2 个：`custom_short`、`custom_long`
- 后端新增字段：
  - `task_type`: `market_window | custom_recurring`
  - `task_slot`: 上述 5 个固定槽位之一
  - `frequency`: `trading_day | daily | weekly | monthly`
  - `horizon`: `short | medium`，其中 `custom_long` 在 UI 上显示为“长期”，内部落为 `medium`
  - `trigger_time`
  - `prompt_mode`: `merge_global | override_global`
  - `custom_prompt`
  - `last_run_key`
- 数据约束改为：
  - 同一用户同一股票同一 `task_slot` 唯一
  - 不再使用“同股票只能一条任务”的约束
- 保持任务总量可直接由槽位模型自然限制为 5，无需额外“最多 N 条”业务判断

### 2. 两类任务的行为规则
- `交易日窗口任务`
  - 固定 3 条槽位
  - 时间固定为 `08:00`、`12:00`、`20:00`
  - 仅在 A 股交易日触发
  - 不开放频率编辑
  - 可编辑的内容仅包括启用状态、股票级提示偏好
  - 默认 horizon：
    - 3 个窗口任务统一使用现有默认周期，建议保持 `short`
- `自定义循环任务`
  - 固定 2 条槽位：`custom_short`、`custom_long`
  - `custom_short` 对应 `short`
  - `custom_long` 对应 `medium`，但 UI 展示为“长期”
  - 可自定义时间
  - 可选择频率：`daily`、`weekly`、`monthly`
  - `daily` 按自然日循环
  - `weekly` 需要选择星期几
  - `monthly` 需要选择每月第几日；若当日非交易日，则回退到最近一个可执行交易日
  - 继续沿用非交易时段限制，除非后续明确放开

### 3. 调度器与执行链路
- 调度器待执行判定从“今天是否跑过 + trigger_time”升级为“当前任务所属周期是否已跑过”
- `last_run_key` 规则：
  - `trading_day` / `daily`：`YYYY-MM-DD`
  - `weekly`：`YYYY-Www`
  - `monthly`：`YYYY-MM`
- 交易日窗口任务：
  - 只有在交易日才参与调度
  - 到对应固定时间后触发
- 自定义循环任务：
  - `daily` 可按自然日判断
  - `weekly/monthly` 到命中的周期和时间后触发
  - 若命中日不是交易日，则按既定回退策略找到最近可执行交易日
- 执行定时分析时拼接 prompt：
  - 系统默认上下文
  - 用户全局提示词
  - 当前定时任务的股票级提示词
  - 本次任务上下文
- 运行完成后写入：
  - `report_source = scheduled`
  - `scheduled_task_id`
  - `scheduled_task_slot`
  - `scheduled_frequency`
  - `prompt_snapshot`

### 4. 全局提示词与股票级偏好
- 将当前仅存在前端 `localStorage` 的全局提示词正式下沉到后端用户配置
- 设置页保存时通过配置接口持久化该字段
- 定时任务增加股票级提示偏好：
  - `merge_global`：全局提示词 + 股票任务提示词
  - `override_global`：只使用股票任务提示词
- 默认采用 `merge_global`
- 聊天分析和定时分析共用同一份全局提示词来源，避免行为不一致

### 5. 前端交互改造
- 自选页中“定时”不再是单开关，而是进入某只股票的“定时任务管理”
- 任务面板按两组展示：
  - `交易日窗口任务`
  - `自定义循环任务`
- UI 规则：
  - 交易日窗口区固定显示 3 张任务卡，显示 08:00 / 12:00 / 20:00，可启停和编辑提示偏好
  - 自定义区固定显示 2 张任务卡：短线、自定义长期；可编辑时间、频率、周/月参数、提示偏好
  - 不允许新增第 6 条任务，也不允许用户创建额外自由槽位
- 报告列表与详情页显示：
  - 是否为定时报告
  - 来自哪个任务槽位
  - 任务频率
  - 必要时显示“窗口任务 / 自定义任务”标签

## 报告差异分析的下一阶段
- 本轮只补足元数据，不做完整 diff 功能
- 下一阶段新增“当前报告 vs 上一份同股票报告”的差异分析能力
- 首版对比内容：
  - 决策变化
  - 置信度变化
  - 目标价 / 止损价变化
  - 关键风险变化
  - 各分析模块文本摘要变化
  - 针对“减持 -> 增持”这类翻转，输出重点差异归因
- 预留入口位置：
  - 报告详情页增加“与上一份对比”
  - 若是定时报告，可优先对比同一任务槽位上一份报告

## 接口与类型变更
- `ScheduledAnalysis` 新增：
  - `task_type`
  - `task_slot`
  - `frequency`
  - `day_of_week`
  - `day_of_month`
  - `prompt_mode`
  - `custom_prompt`
- `/v1/scheduled` 创建与更新请求新增：
  - `task_slot`
  - `frequency`
  - `day_of_week`
  - `day_of_month`
  - `prompt_mode`
  - `custom_prompt`
- `RuntimeConfig` / `RuntimeConfigUpdate` 新增：
  - `analysis_prompt`
- `Report` / `ReportDetail` 新增：
  - `report_source`
  - `scheduled_task_id`
  - `scheduled_task_slot`
  - `scheduled_frequency`
  - `prompt_snapshot`

## 测试计划
- 数据层：
  - 同一股票只能创建 5 个固定槽位中的合法任务
  - 同一槽位重复创建被拒绝
  - 老数据可迁移为兼容结构
- 调度层：
  - 交易日窗口任务仅在交易日 `08:00/12:00/20:00` 触发
  - 自定义 `daily/weekly/monthly` 判定正确
  - `monthly` 命中非交易日时回退行为正确
  - `custom_long` 正确落为 `medium`
- Prompt 层：
  - 全局提示词保存并可被定时分析读取
  - `merge_global` 和 `override_global` 拼接结果正确
  - 报告正确保存 prompt 快照
- 前端：
  - 某只股票固定展示 3 个窗口任务 + 2 个自定义任务位
  - 可编辑自定义短线/长期任务的频率与时间
  - 报告页正确展示定时来源标签
- 回归：
  - 手动分析流程不变
  - 自选股列表和历史报告查询不退化
  - 邮件报告与定时失败停用逻辑保持可用

## 默认假设
- 交易日窗口任务的 3 个时间固定，不开放修改
- 自定义循环任务只有 2 个固定槽位，不支持继续新增更多自由任务
- “长期”仅为前端业务文案，内部统一映射到现有 `medium`
- `daily` 自定义任务按自然日循环；交易日窗口任务则按交易日循环
- 本轮不实现报告回调，仅为差异分析补充基础元数据
`