### PR TITLE
ci: deploy to Vercel only on tag push via Vercel CLI

### DIFF
--- a/.github/workflows/vercel-deploy-on-tag.yml
+++ b/.github/workflows/vercel-deploy-on-tag.yml
@@ -1,0 +1,33 @@
+name: Deploy to Vercel on tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel project settings
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: frontend
+
+      - name: Build
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: frontend
+
+      - name: Deploy exact tagged commit to production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: frontend

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "ignoreBuildStep": "if git describe --tags --exact-match HEAD > /dev/null 2>&1; then exit 1; else exit 0; fi"
+    "ignoreBuildStep": "exit 1"
   },
   "framework": "vite",
   "rewrites": [


### PR DESCRIPTION
- Add GitHub Action that triggers on v* tags, checks out the exact tagged commit, and deploys to Vercel production using Vercel CLI
- Change ignoreBuildStep to always skip — Vercel's auto-build on branch push is no longer used; only explicit tag-based deploys