### PR TITLE
fix: 消除 Docker 容器启动时的重复依赖安装

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # 利用 uv 同步依赖（uv 在多架构环境下依然非常快）
+# 先只装第三方依赖（利用 Docker 层缓存）
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-install-project --no-dev
@@ -24,6 +25,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # 拷贝后端源码
 COPY api/ ./api/
 COPY tradingagents/ ./tradingagents/
+
+# 安装项目本身，避免 uv run 启动时重复安装
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
 
 # 拷贝在 Stage 1 中快速构建好的前端产物
 COPY --from=frontend-builder /app/frontend/dist ./frontend/dist
@@ -40,4 +45,4 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
 # 启动命令
-CMD ["uv", "run", "tradingagents-api"]
+CMD ["uv", "run", "--no-sync", "tradingagents-api"]


### PR DESCRIPTION
## Summary

- build 阶段源码 COPY 后补充 `uv sync --frozen --no-dev`，将项目本身也安装到虚拟环境
- 启动命令改为 `uv run --no-sync`，跳过运行时依赖检查

之前 `--no-install-project` 导致项目未在 build 阶段安装，每次容器启动 `uv run` 都会重新 build + install 项目及缺失依赖。

## Test plan

- [ ] `docker build` 验证镜像构建成功
- [ ] `docker run` 验证启动日志不再出现 `Building tradingagents` / `Installed N packages`