### PR TITLE
fix: 启动恢复逻辑校验报告归属，防止定时任务假成功

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -439,20 +439,34 @@ async def lifespan(app: FastAPI):
             ScheduledAnalysisDB.last_run_status == "running"
         ).all()
         if stale:
+            recovered_count = 0
+            reset_count = 0
             for item in stale:
                 # 检查是否已有对应的成功报告（任务实际完成了但状态卡在 running）
-                has_report = item.last_report_id and db.query(ReportDB).filter(
-                    ReportDB.id == item.last_report_id,
-                    ReportDB.status == "completed",
-                ).first()
+                # 必须同时校验报告是本次运行产生的（created_at >= last_run_date），
+                # 否则 last_report_id 指向的旧报告会导致假成功。
+                has_report = (
+                    item.last_report_id
+                    and item.last_run_date
+                    and db.query(ReportDB).filter(
+                        ReportDB.id == item.last_report_id,
+                        ReportDB.status == "completed",
+                        ReportDB.created_at >= item.last_run_date,
+                    ).first()
+                )
                 if has_report:
                     item.last_run_status = "success"
                     # 保留 last_run_date，不重新触发
+                    recovered_count += 1
                 else:
                     item.last_run_status = "stale"
                     item.last_run_date = None  # 真正未完成，允许重新触发
+                    reset_count += 1
             db.commit()
-            _log(f"[Scheduler] Reset {len(stale)} stale 'running' tasks on startup.")
+            _log(
+                f"[Scheduler] Reset {len(stale)} stale 'running' tasks on startup "
+                f"(recovered={recovered_count}, reset_to_stale={reset_count})."
+            )
         report_reset = report_service.recover_stale_active_reports(db)
         if report_reset["total"]:
             _log(


### PR DESCRIPTION
## Summary

- 启动时 stale recovery 用 `last_report_id` 判断任务是否已完成，但未校验报告是否属于**本次运行**
- 当定时任务 acquired slot 后挂死、容器重启时，`last_report_id` 仍指向旧报告（前几天的），recovery 误判为 `success` 并保留 `last_run_date=今天`，导致当天任务永不重跑
- 生产环境确认：74 个标记 `success` 的任务，无一对应今天生成的报告
- 修复：增加 `created_at >= last_run_date` 条件，确保只有本次运行产生的报告才能恢复为 success
- 增加 `recovered`/`reset_to_stale` 计数日志便于排查

## Test plan

- [ ] 模拟场景：`last_report_id` 指向旧 completed 报告，`last_run_date` 为今天 → 应 reset 为 stale
- [ ] 模拟场景：`last_report_id` 指向今天 completed 报告 → 应 recover 为 success
- [ ] 验证启动日志输出 recovered/reset 计数
- [ ] 部署后观察下一次定时任务是否正常触发