### PR TITLE
fix: always run short horizon only (medium is redundant)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1866,9 +1866,8 @@ async def _run_job_inner(
         )
         final_state: Optional[Dict[str, Any]] = None
 
-        # Ensure horizons is never empty
-        if not request.horizons:
-            request.horizons = ["short"]
+        # Ensure horizons is never empty; always run short only (medium is redundant)
+        request.horizons = ["short"]
 
         # ── Dual-horizon intent-driven path ──────────────────────────────────
         if request.query:


### PR DESCRIPTION
 medium 和 short 的区别只是 prompt 里的"视角描述"，流程完全一样                                                        
                                                                                                                        
  每个 analyst 都硬编码了自己的 horizon，不受传入的 state["horizon"] 影响：                                             
                                                                                                                        
  - market/social/news/volume_price → 永远用 "short" 视角                                                               
  - fundamentals/macro → 永远用 "medium" 视角
  - bull/bear researcher → 读 state.get("horizon", "medium")                                                            
                                                                                                                        
  所以不管你传 horizons=["short"] 还是 ["short","medium"]，每个 analyst 的行为完全一样。                                
                                                                                                                        
  跑2次的原因：                                                                                                         
                  
  horizons=["short","medium"] 时，代码在 asyncio.gather 里并行跑两个完整的 graph：                                      
                  
  results = await asyncio.gather(                                                                                       
      *[_process_horizon(h) for h in request.horizons],  # 跑2遍                                                        
  )                                                                                                                     
                                                                                                                        
  每遍都是完整的 6个analysts + bull/bear + trader + 风控，两遍产出的内容几乎一模一样，最后只取 short 的结果，medium     
  的只保留 traces。                                                                                                     
                                                                                                                        
  结论：                                                                                                                
   
  - medium 不是"不同模型"，也不是"不同流程"                                                                             
  - 就是多跑一遍一样的东西，纯粹浪费时间
  - 用户说"中线"触发 dual_horizon，执行时间直接翻倍                                                                     
                                                                                                                        
  如果你想真正支持中线分析，需要让 fundamentals/macro analyst 根据传入的 horizon 动态调整数据窗口和                     
  prompt，而不是硬编码。目前的实现 dual_horizon 没有实际意义。