### PR TITLE
fix: 赞助/致谢页面重定向到线上地址

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,9 +10,14 @@ import Portfolio from './pages/Portfolio'
 import TrackingBoard from './pages/TrackingBoard'
 import Login from './pages/Login'
 import Feedback from './pages/Feedback'
-import Sponsor from './pages/Sponsor'
-import Thanks from './pages/Thanks'
 import { useAuthStore } from './stores/authStore'
+
+const ONLINE_BASE = 'https://app.510168.xyz'
+
+function ExternalRedirect({ to }: { to: string }) {
+  window.location.href = to
+  return null
+}
 
 function RequireAuth({ children }: { children: JSX.Element }) {
   const { user, hydrated, hydrate } = useAuthStore()
@@ -37,8 +42,8 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
-        <Route path="/sponsor" element={<Sponsor />} />
-        <Route path="/thanks" element={<Thanks />} />
+        <Route path="/sponsor" element={<ExternalRedirect to={`${ONLINE_BASE}/sponsor`} />} />
+        <Route path="/thanks" element={<ExternalRedirect to={`${ONLINE_BASE}/thanks`} />} />
         <Route
           path="*"
           element={


### PR DESCRIPTION
## Summary
- `/sponsor` 和 `/thanks` 路由改为重定向到 `app.510168.xyz` 对应页面
- Docker 部署的用户访问这两个页面时直接跳转线上，始终展示最新赞助商和致谢信息
- 线上页面更新后所有 Docker 实例自动生效，无需重新部署

## Test plan
- [ ] 访问 `/sponsor` 跳转到 `https://app.510168.xyz/sponsor`
- [ ] 访问 `/thanks` 跳转到 `https://app.510168.xyz/thanks`