### PR TITLE
fix: 前端 API 地址动态获取、分析超时优化、辩论弹框深色背景文字修复

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -300,7 +300,7 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-_JOB_TIMEOUT = int(os.getenv("TA_JOB_TIMEOUT", "600"))  # seconds
+_JOB_TIMEOUT = int(os.getenv("TA_JOB_TIMEOUT", "1800"))  # seconds (默认 30 分钟，适配多 Agent 长流程分析)
 def _create_tracked_task(coro, *, label: str = "Background task") -> asyncio.Task:
     """Create an asyncio task and keep a reference to prevent GC.
     Also logs unhandled exceptions via a done callback."""

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,13 +28,12 @@ cd frontend
 npm install
 ```
 
-### 2. 配置环境变量
+### 2. API 地址说明
 
-创建 `.env` 文件：
+前端默认使用当前访问地址作为 API 地址，即 `window.location.origin`。
 
-```env
-VITE_API_URL=http://localhost:8000
-```
+- 访问 `http://localhost:5173` 时，请使用 Vite 代理转发到后端。
+- 生产环境中，前端静态资源和后端 API 由同一个服务/域名提供，无需配置固定 API 地址。
 
 ### 3. 启动开发服务器
 

--- a/frontend/src/components/DebateDrawer.tsx
+++ b/frontend/src/components/DebateDrawer.tsx
@@ -73,7 +73,7 @@ export default function DebateDrawer({ debate, onClose }: DebateDrawerProps) {
             />
 
             {/* Drawer */}
-            <div className="fixed top-0 right-0 h-full w-1/2 max-w-[720px] min-w-[400px] bg-slate-900 border-l border-slate-700 shadow-2xl z-50 flex flex-col animate-in slide-in-from-right duration-300">
+            <div className="fixed top-0 right-0 h-full w-1/2 max-w-[720px] min-w-[400px] dark bg-slate-900 border-l border-slate-700 shadow-2xl z-50 flex flex-col animate-in slide-in-from-right duration-300">
                 {/* Header */}
                 <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
                     <div className="flex items-center gap-3">

--- a/frontend/src/components/DebateTimeline.tsx
+++ b/frontend/src/components/DebateTimeline.tsx
@@ -82,7 +82,7 @@ export default function DebateTimeline({ messages, debate }: DebateTimelineProps
                                                 </span>
                                             )}
                                         </div>
-                                        <div className="prose dark:prose-invert prose-sm max-w-none text-sm leading-relaxed">
+                                        <div className="prose-sm max-w-none text-sm leading-relaxed text-slate-200">
                                             <ReactMarkdown remarkPlugins={[remarkGfm]}>
                                                 {msg.content}
                                             </ReactMarkdown>
@@ -112,7 +112,7 @@ export default function DebateTimeline({ messages, debate }: DebateTimelineProps
                                 {debate === 'research' ? '研究总监裁决' : '风控裁决'}
                             </span>
                         </div>
-                        <div className="prose dark:prose-invert prose-sm max-w-none text-sm leading-relaxed">
+                        <div className="prose-sm max-w-none text-sm leading-relaxed text-slate-200">
                             <ReactMarkdown remarkPlugins={[remarkGfm]}>
                                 {verdict.content}
                             </ReactMarkdown>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,8 +1,6 @@
 import type { AnalysisRequest, AnalysisResponse, Announcement, AuthUser, AuthVerifyResponse, JobStatus, AnalysisReport, KlineResponse, LatestAnnouncementResponse, PortfolioImportState, PortfolioOverviewResponse, PortfolioPositionInput, Report, ReportDetail, ReportListResponse, RuntimeConfig, RuntimeConfigUpdate, RuntimeConfigUpdateResponse, RuntimeWarmupRequest, RuntimeWarmupResponse, WatchlistItem, WatchlistBatchResponse, ScheduledAnalysis, ScheduledBatchTriggerResponse, StockSearchResult, TrackingBoardResponse, UserToken, UserTokenCreateRequest, WecomWarmupRequest, WecomWarmupResponse, FeedbackItem, FeedbackListResponse, FeedbackUnreadResponse } from '@/types'
 
 export function getBaseUrl(): string {
-    const envUrl = (import.meta.env.VITE_API_URL as string) || ''
-    if (envUrl) return envUrl.replace(/\/$/, '')
     if (typeof window !== 'undefined' && window.location?.origin) {
         return window.location.origin.replace(/\/$/, '')
     }


### PR DESCRIPTION
## 修改内容

### 1. 前端 API 地址动态获取

**问题**：前端 API 地址硬编码 `localhost:8000`，部署到其他域名/IP 时无法正常工作。

**修复**：
- 修改 `frontend/src/services/api.ts`，API 基础地址改为跟随 `window.location.origin` 动态获取
- 删除 `frontend/.env.local` 硬编码配置

**效果**：无论通过域名、IP、反代访问，前端都能正确连接后端 API。

---

### 2. 智能分析超时优化

**问题**：多 Agent 协作分析流程耗时较长，默认 600s 超时导致分析中断。

**修复**：
- 修改 `api/main.py`，将 `_JOB_TIMEOUT` 默认值从 `600` 提升至 `1800`（30 分钟）

**效果**：完整的多 Agent 分析流程（7 个分析师 + 多空辩论 + 风控辩论 + Trader 决策）可正常完成。

---

### 3. 辩论弹框深色背景文字颜色修复

**问题**：多空辩论/风控辩论弹框中，Markdown 文字颜色与深色背景融为一体，无法正常阅读。

**根因**：
- `DebateDrawer` 容器直接使用了 `bg-slate-900` 深色背景，但未添加 `dark` class
- `DebateTimeline` 中的 Markdown 内容使用了 `prose dark:prose-invert` 类，但项目未安装 `@tailwindcss/typography` 插件
- 导致 `dark:prose-invert` 不生效，Markdown 文本继承了默认的深色文字颜色，在深色背景上不可见

**修复**：
- `frontend/src/components/DebateDrawer.tsx`：容器添加 `dark` class 激活 Tailwind 暗色模式
- `frontend/src/components/DebateTimeline.tsx`：Markdown 内容显式设置 `text-slate-200` 浅色文字

**效果**：多空辩论和风控辩论弹框文字清晰可读，裁决卡片 Markdown 内容正常显示。

---

## 影响文件

- `frontend/src/services/api.ts`
- `frontend/.env.local`（删除）
- `api/main.py`
- `frontend/src/components/DebateDrawer.tsx`
- `frontend/src/components/DebateTimeline.tsx`