### PR TITLE
Fix Docker frontend API base URL for remote deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+frontend/.env*.local
+frontend/node_modules
+frontend/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1: Build Frontend (始终在原生架构运行以提速)
 FROM --platform=$BUILDPLATFORM node:25-slim AS frontend-builder
 WORKDIR /app/frontend
+ARG VITE_API_URL=""
+ENV VITE_API_URL=${VITE_API_URL}
 COPY frontend/package*.json ./
 # 开启缓存挂载，加速 npm 安装
 RUN --mount=type=cache,target=/root/.npm npm install

--- a/README.md
+++ b/README.md
@@ -102,14 +102,19 @@ export TA_APP_SECRET_KEY=$(openssl rand -base64 32)
 docker run -d -p 8000:8000 \
   --name tradingagents \
   -v $(pwd)/data:/app/data \
+  -e APP_ENV=production \
   -e DATABASE_URL="sqlite:///./data/tradingagents.db" \
   -e TA_APP_SECRET_KEY="${TA_APP_SECRET_KEY}" \
   ghcr.io/kylinmountain/tradingagents-ashare:latest
 ```
 
-访问 `http://localhost:8000` 即可使用。
+本镜像默认以前后端同源方式工作，前端 API 请求使用 `/v1/...` 相对路径。部署在远程服务器时，请通过 `http://<服务器IP>:8000` 或绑定的域名访问；只有在浏览器和容器运行在同一台本机时才使用 `http://localhost:8000`。
+
+不要在生产构建中设置 `VITE_API_URL=http://localhost:8000`。浏览器中的 `localhost` 指向访问者自己的机器，不是 Docker 服务器。仅当前后端分离部署时，才在前端构建阶段显式设置 `VITE_API_URL` 为真实后端地址。
 
 > **`TA_APP_SECRET_KEY`**：用于加密用户 LLM API Key 和签发登录 JWT。不设置时使用内置默认密钥（仅适合本地开发）。生产环境务必设置，且不可更改。
+
+> **邮箱验证码**：如果要真正发送邮件验证码，需要配置 `MAIL_HOST`、`MAIL_PORT`、`MAIL_USER`、`MAIL_PASS`、`MAIL_FROM`、`MAIL_SSL`。未配置 SMTP 且 `APP_ENV` 不是 `production` 时，系统可能返回 `dev_code` 或在日志打印验证码，这是开发便利行为，不应暴露在公网生产环境。
 
 > **LLM 配置**：启动后在前端"设置"页面配置模型厂商、API Key 和模型名称即可，无需环境变量预设。
 

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost:8000

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,13 +28,17 @@ cd frontend
 npm install
 ```
 
-### 2. 配置环境变量
+### 2. 配置环境变量（可选）
 
-创建 `.env` 文件：
+默认不需要配置 `VITE_API_URL`。未设置时，前端使用同源相对 API 路径 `/v1/...`；本地开发服务通过 `vite.config.ts` 代理到 `http://localhost:8000`。
+
+只有当前后端分离部署时，才创建 `.env.local` 并设置真实后端地址：
 
 ```env
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=https://api.example.com
 ```
+
+不要在生产构建中设置 `VITE_API_URL=http://localhost:8000`，否则远程浏览器会请求访问者本机的 localhost。
 
 ### 3. 启动开发服务器
 

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getBaseUrl } from '@/services/api'
+
+describe('getBaseUrl', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('uses same-origin relative paths when VITE_API_URL is not configured', () => {
+        vi.stubEnv('VITE_API_URL', '')
+
+        expect(getBaseUrl()).toBe('')
+    })
+
+    it('uses an explicit API URL without a trailing slash when configured', () => {
+        vi.stubEnv('VITE_API_URL', ' https://api.example.test/ ')
+
+        expect(getBaseUrl()).toBe('https://api.example.test')
+    })
+})

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,12 +1,9 @@
 import type { AnalysisRequest, AnalysisResponse, Announcement, AuthUser, AuthVerifyResponse, JobStatus, AnalysisReport, KlineResponse, LatestAnnouncementResponse, PortfolioImportState, PortfolioOverviewResponse, PortfolioPositionInput, Report, ReportDetail, ReportListResponse, RuntimeConfig, RuntimeConfigUpdate, RuntimeConfigUpdateResponse, RuntimeWarmupRequest, RuntimeWarmupResponse, WatchlistItem, WatchlistBatchResponse, ScheduledAnalysis, ScheduledBatchTriggerResponse, StockSearchResult, TrackingBoardResponse, UserToken, UserTokenCreateRequest, WecomWarmupRequest, WecomWarmupResponse, FeedbackItem, FeedbackListResponse, FeedbackUnreadResponse } from '@/types'
 
 export function getBaseUrl(): string {
-    const envUrl = (import.meta.env.VITE_API_URL as string) || ''
+    const envUrl = (import.meta.env.VITE_API_URL as string | undefined)?.trim()
     if (envUrl) return envUrl.replace(/\/$/, '')
-    if (typeof window !== 'undefined' && window.location?.origin) {
-        return window.location.origin.replace(/\/$/, '')
-    }
-    return 'http://localhost:8000'
+    return ''
 }
 
 

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-    readonly VITE_API_URL: string
+    readonly VITE_API_URL?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Problem:
When the Docker image is deployed on a remote host and accessed via http://<server-ip>:8000, the login page can show Failed to fetch. The backend endpoint itself works, but browser requests may be sent to http://localhost:8000, which points to the visitor's local machine instead of the Docker host.

Root cause:
The frontend default API base URL could fall back to http://localhost:8000, and the tracked frontend/.env.local file also caused Vite/Docker builds to bake that value into the production bundle.

Fix:
Use same-origin relative API paths by default when VITE_API_URL is not explicitly configured. Keep VITE_API_URL support for split frontend/backend deployments. Remove the tracked frontend/.env.local file and add .dockerignore rules so local frontend env files are not copied into Docker builds.

Verification:
- Added Vitest coverage for getBaseUrl default and explicit VITE_API_URL behavior.
- Ran `npx vitest run` from frontend: 3 files, 11 tests passed.
- Ran `npm run build` from frontend: production build completed.
- Searched frontend/dist and confirmed it does not contain `http://localhost:8000` or `localhost:8000`.
- Confirmed local FastAPI served JS did not contain `localhost:8000` and `POST /v1/auth/request-code` returned 200 OK during local verification.
- Docker image verification was not run in this local environment because the `docker` command is not installed.

Compatibility notes:
Docker single-container deployments now use the current origin by default for `/v1/...` API calls. Split frontend/backend deployments can still set VITE_API_URL explicitly at build time. Production deployments should avoid `VITE_API_URL=http://localhost:8000` because browser localhost refers to the visitor's machine.