### PR TITLE
[codex] Bound insider fallback news to analysis date

### DIFF
--- a/tests/test_cn_akshare_insider_transactions.py
+++ b/tests/test_cn_akshare_insider_transactions.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from tradingagents.dataflows.providers.cn_akshare_provider import CnAkshareProvider
+
+
+class _EmptyAkshareClient:
+    def stock_main_stock_holder(self, stock):
+        return pd.DataFrame()
+
+
+class _NewsFallbackProvider(CnAkshareProvider):
+    def __init__(self):
+        self.news_calls = []
+
+    def _ak(self):
+        return _EmptyAkshareClient()
+
+    def get_news(self, ticker: str, start_date: str, end_date: str) -> str:
+        self.news_calls.append((ticker, start_date, end_date))
+        return "fallback news"
+
+
+def test_insider_transactions_fallback_uses_analysis_date_window():
+    provider = _NewsFallbackProvider()
+
+    result = provider.get_insider_transactions("600519.SH", curr_date="2024-01-15")
+
+    assert "fallback news" in result
+    assert provider.news_calls == [("600519.SH", "2024-01-01", "2024-01-15")]

--- a/tradingagents/agents/utils/news_data_tools.py
+++ b/tradingagents/agents/utils/news_data_tools.py
@@ -41,13 +41,15 @@ def get_global_news(
 @tool
 def get_insider_transactions(
     ticker: Annotated[str, "ticker symbol"],
+    curr_date: Annotated[str | None, "Current analysis date in yyyy-mm-dd format"] = None,
 ) -> str:
     """
     Retrieve insider transaction information about a company.
     Uses the configured news_data vendor.
     Args:
         ticker (str): Ticker symbol of the company
+        curr_date (str | None): Analysis date used by date-sensitive fallbacks
     Returns:
         str: A report of insider transaction data
     """
-    return route_to_vendor("get_insider_transactions", ticker)
+    return route_to_vendor("get_insider_transactions", ticker, curr_date=curr_date)

--- a/tradingagents/dataflows/providers/alpha_vantage_provider.py
+++ b/tradingagents/dataflows/providers/alpha_vantage_provider.py
@@ -51,6 +51,5 @@ class AlphaVantageProvider(BaseMarketDataProvider):
     ) -> str:
         return get_alpha_vantage_global_news(curr_date, look_back_days, limit)
 
-    def get_insider_transactions(self, symbol: str) -> str:
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
         return get_alpha_vantage_insider_transactions(symbol)
-

--- a/tradingagents/dataflows/providers/base.py
+++ b/tradingagents/dataflows/providers/base.py
@@ -53,7 +53,7 @@ class BaseMarketDataProvider(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_insider_transactions(self, symbol: str) -> str:
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
         raise NotImplementedError
 
     def get_realtime_quotes(self, symbols: list[str]) -> str:
@@ -63,4 +63,3 @@ class BaseMarketDataProvider(ABC):
         price, open, high, low, previous_close, change, change_pct, volume, amount.
         """
         raise NotImplementedError
-

--- a/tradingagents/dataflows/providers/china_equity_provider.py
+++ b/tradingagents/dataflows/providers/china_equity_provider.py
@@ -50,5 +50,5 @@ class CnStubProvider(BaseMarketDataProvider):
     ) -> str:
         return self._not_implemented()
 
-    def get_insider_transactions(self, symbol: str) -> str:
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
         return self._not_implemented()

--- a/tradingagents/dataflows/providers/cn_akshare_provider.py
+++ b/tradingagents/dataflows/providers/cn_akshare_provider.py
@@ -664,7 +664,7 @@ class CnAkshareProvider(BaseMarketDataProvider):
                     f"cn_akshare is temporarily unavailable for global news: {exc}"
                 ) from exc
 
-    def get_insider_transactions(self, symbol: str) -> str:
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
         ak = self._ak()
         code = self._normalize_symbol(symbol)
         errors = []
@@ -683,8 +683,9 @@ class CnAkshareProvider(BaseMarketDataProvider):
 
         try:
             # 退化为最近相关新闻，至少保证接口有可用输出
-            end_date = datetime.now().strftime("%Y-%m-%d")
-            start_date = (datetime.now() - timedelta(days=14)).strftime("%Y-%m-%d")
+            end_dt = datetime.strptime(curr_date, "%Y-%m-%d") if curr_date else datetime.now()
+            end_date = end_dt.strftime("%Y-%m-%d")
+            start_date = (end_dt - timedelta(days=14)).strftime("%Y-%m-%d")
             news = self.get_news(symbol, start_date, end_date)
             return (
                 f"## Insider Transactions for {symbol}\n\n"

--- a/tradingagents/dataflows/providers/cn_baostock_provider.py
+++ b/tradingagents/dataflows/providers/cn_baostock_provider.py
@@ -202,7 +202,7 @@ class CnBaoStockProvider(BaseMarketDataProvider):
     ) -> str:
         raise NotImplementedError("cn_baostock does not provide global news yet.")
 
-    def get_insider_transactions(self, symbol: str) -> str:
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
         raise NotImplementedError(
             "cn_baostock does not provide insider transactions yet."
         )

--- a/tradingagents/dataflows/providers/yfinance_provider.py
+++ b/tradingagents/dataflows/providers/yfinance_provider.py
@@ -59,5 +59,5 @@ class YFinanceProvider(BaseMarketDataProvider):
     ) -> str:
         return get_global_news_yfinance(curr_date, look_back_days, limit)
 
-    def get_insider_transactions(self, symbol: str) -> str:
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
         return get_yfinance_insider_transactions(self._normalize_symbol(symbol))

--- a/tradingagents/graph/data_collector.py
+++ b/tradingagents/graph/data_collector.py
@@ -274,7 +274,7 @@ def _fetch_all(ticker: str, trade_date: str) -> Dict[str, Any]:
         "fund_flow_board": (get_board_fund_flow, {}),
         "fund_flow_individual": (get_individual_fund_flow, {"symbol": ticker}),
         "lhb": (get_lhb_detail, {"symbol": ticker, "date": trade_date}),
-        "insider_transactions": (get_insider_transactions, {"ticker": ticker}),
+        "insider_transactions": (get_insider_transactions, {"ticker": ticker, "curr_date": trade_date}),
         "zt_pool": (get_zt_pool, {"date": trade_date}),
         "hot_stocks": (get_hot_stocks_xq, {}),
     }


### PR DESCRIPTION
## Summary
- Add an optional `curr_date` argument to `get_insider_transactions` and pass it from the data collector.
- Use `curr_date` as the end of the cn_akshare news fallback window when shareholder transaction data is unavailable.
- Keep provider compatibility by allowing other providers to accept and ignore the new optional argument.

## Why this matters
Historical A-share analysis should not mix future/current news into a past trade date. This keeps financial agent backtests and retrospective research prompts bounded to information available on the analysis date.

## Validation
- `python -m py_compile tradingagents/dataflows/providers/base.py tradingagents/dataflows/providers/yfinance_provider.py tradingagents/dataflows/providers/cn_baostock_provider.py tradingagents/dataflows/providers/alpha_vantage_provider.py tradingagents/dataflows/providers/china_equity_provider.py tradingagents/dataflows/providers/cn_akshare_provider.py tradingagents/agents/utils/news_data_tools.py tradingagents/graph/data_collector.py tests/test_cn_akshare_insider_transactions.py`
- Direct provider fallback test with mocked akshare and news provider passed.
- `git diff --check`

Note: full pytest was not run locally because this environment does not have `pytest` installed.