### PR TITLE
chore(deps): bump lucide-react to 1.8.0 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "clsx": "^2.1.0",
         "date-fns": "^4.4.0",
         "lightweight-charts": "^5.2.0",
-        "lucide-react": "^0.344.0",
+        "lucide-react": "^1.8.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0",
@@ -3745,12 +3745,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.344.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.344.0.tgz",
-      "integrity": "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.0",
     "date-fns": "^4.4.0",
     "lightweight-charts": "^5.2.0",
-    "lucide-react": "^0.344.0",
+    "lucide-react": "^1.8.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",

--- a/frontend/src/components/GithubIcon.tsx
+++ b/frontend/src/components/GithubIcon.tsx
@@ -1,0 +1,24 @@
+import type { SVGProps } from 'react'
+
+// lucide-react dropped brand icons (incl. Github) from v1.0 onward.
+// Inlined from lucide-react v0.344.0's github.tsx to keep the same look.
+export default function GithubIcon({ className, ...rest }: SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={24}
+            height={24}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            {...rest}
+        >
+            <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+            <path d="M9 18c-4.51 2-5-2-7-2" />
+        </svg>
+    )
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Bell, BellOff, ChevronDown, LogOut, Monitor, Moon, Settings, Sun, Github, Heart, Megaphone, Users } from 'lucide-react'
+import { Bell, BellOff, ChevronDown, LogOut, Monitor, Moon, Settings, Sun, Heart, Megaphone, Users } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
 import { api } from '@/services/api'
 import { useAuthStore } from '@/stores/authStore'
 import type { Announcement } from '@/types'
+import GithubIcon from './GithubIcon'
 
 type ThemeMode = 'system' | 'light' | 'dark'
 
@@ -218,7 +219,7 @@ export default function Header() {
                         className="group flex items-center gap-2 rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-3 py-1.5 hover:border-slate-300 dark:hover:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-900/90 transition-all mr-1"
                         title="Star us on GitHub"
                     >
-                        <Github className="w-4 h-4 text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white" />
+                        <GithubIcon className="w-4 h-4 text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white" />
                         <span className="text-[13px] font-medium text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white hidden sm:inline">Star</span>
                     </a>
                     {user && (

--- a/frontend/src/pages/Sponsor.tsx
+++ b/frontend/src/pages/Sponsor.tsx
@@ -1,5 +1,6 @@
-import { Heart, Github, ArrowLeft } from 'lucide-react'
+import { Heart, ArrowLeft } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
+import GithubIcon from '@/components/GithubIcon'
 
 const GITHUB_URL = 'https://github.com/KylinMountain/TradingAgents-AShare'
 
@@ -65,7 +66,7 @@ export default function Sponsor() {
                             rel="noopener noreferrer"
                             className="flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
                         >
-                            <Github className="w-4 h-4" />
+                            <GithubIcon className="w-4 h-4" />
                             GitHub
                         </a>
                     </div>

--- a/frontend/src/pages/Thanks.tsx
+++ b/frontend/src/pages/Thanks.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { ArrowLeft, Github, Heart, Cpu, Code2, ExternalLink } from 'lucide-react'
+import { ArrowLeft, Heart, Cpu, Code2, ExternalLink } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { getBaseUrl } from '@/services/api'
+import GithubIcon from '@/components/GithubIcon'
 
 const GITHUB_REPO = 'KylinMountain/TradingAgents-AShare'
 const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPO}/contributors?per_page=100`
@@ -77,7 +78,7 @@ function SponsorCard({ name, github, avatar, email, date, badge, badgeColor, ext
                     <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">{name}</span>
                     {github && (
                         <a href={`https://github.com/${github}`} target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors">
-                            <Github className="w-3.5 h-3.5" />
+                            <GithubIcon className="w-3.5 h-3.5" />
                         </a>
                     )}
                 </div>
@@ -247,7 +248,7 @@ export default function Thanks() {
                         {/* Upstream Project */}
                         <section>
                             <div className="flex items-center gap-2 mb-3">
-                                <Github className="w-4 h-4 text-slate-500" />
+                                <GithubIcon className="w-4 h-4 text-slate-500" />
                                 <h2 className="text-sm font-bold text-slate-900 dark:text-slate-100 tracking-wide">上游项目</h2>
                             </div>
                             <a


### PR DESCRIPTION
## Summary
- Bumps `lucide-react` 0.344.0 → 1.8.0 (dependabot #149).
- lucide-react removed all brand icons starting v1.0 — `Github` no longer exists in the package (confirmed via `Object.keys(require('lucide-react'))`, along with its aliases `GithubIcon`/`LucideGithub`, all gone).
- `Header.tsx`, `Sponsor.tsx`, and `Thanks.tsx` (×2) all imported `Github` — merging #149 as-is would have broken the build.
- Fixed by inlining a local `frontend/src/components/GithubIcon.tsx`, copying the exact SVG path data from lucide-react v0.344.0's source so it renders identically, and swapping all 4 usages to it.

## Test plan
- [x] Diffed all 58 icon names actually imported from `lucide-react` across the codebase against 1.8.0's exports — only `Github` was missing
- [x] `npm install` (0 vulnerabilities)
- [x] `npm run build` (tsc + vite build succeed)
- [x] `npx vitest run` (9/9 pass)