### PR TITLE
fix(signal): negation-aware keyword matching to stop biased BUY decisions

### DIFF
--- a/tests/test_signal_processing.py
+++ b/tests/test_signal_processing.py
@@ -1,0 +1,40 @@
+"""Tests for rule-based decision extraction in signal_processing.py."""
+
+from tradingagents.graph.signal_processing import _extract_decision_keyword
+
+
+def test_negated_buy_phrase_is_not_buy():
+    text = "最终建议: 不建议买入，维持观望"
+    assert _extract_decision_keyword(text) == "HOLD"
+
+
+def test_negated_build_position_is_not_buy():
+    text = "风险大于收益，不宜建仓，建议持有观望"
+    assert _extract_decision_keyword(text) == "HOLD"
+
+
+def test_avoid_chasing_and_negated_build_position_is_sell():
+    text = "核心定性：风险偏高，回避追高，暂不建仓"
+    assert _extract_decision_keyword(text) == "SELL"
+
+
+def test_plain_sell_is_sell():
+    assert _extract_decision_keyword("最终建议：卖出") == "SELL"
+
+
+def test_plain_hold_is_hold():
+    assert _extract_decision_keyword("最终建议：观望为主") == "HOLD"
+
+
+def test_plain_buy_is_buy():
+    assert _extract_decision_keyword("最终建议：买入") == "BUY"
+
+
+def test_cautious_bullish_with_unrelated_caveat_is_still_buy():
+    text = "方向：看多，谨慎看多为主，但需回避短期回调风险"
+    assert _extract_decision_keyword(text) == "BUY"
+
+
+def test_issue_191_example_is_buy():
+    text = "风控结论：买入 (需方案修正)"
+    assert _extract_decision_keyword(text) == "BUY"

--- a/tradingagents/graph/signal_processing.py
+++ b/tradingagents/graph/signal_processing.py
@@ -107,11 +107,29 @@ def _extract_decision_keyword(text: str) -> str | None:
             "中性",
         ]
 
-        if any(k in snippet_upper for k in buy_keywords):
+        # 中文风控/交易结论里常见"不建议买入""暂不建仓"这类否定表述，
+        # 关键词子串匹配会命中"买入"/"建仓"而误判为 BUY。这里检查关键词前
+        # 一小段窗口内是否存在否定词，命中则该关键词不计入该方向的信号。
+        negation_markers = ("不", "非", "无需", "别", "切勿", "勿", "避免", "谨防")
+
+        def has_signal(keywords: list[str]) -> bool:
+            for kw in keywords:
+                start = 0
+                while True:
+                    idx = snippet_upper.find(kw, start)
+                    if idx == -1:
+                        break
+                    window = snippet_upper[max(0, idx - 6):idx]
+                    if not any(neg in window for neg in negation_markers):
+                        return True
+                    start = idx + 1
+            return False
+
+        if has_signal(buy_keywords):
             return "BUY"
-        if any(k in snippet_upper for k in sell_keywords):
+        if has_signal(sell_keywords):
             return "SELL"
-        if any(k in snippet_upper for k in hold_keywords):
+        if has_signal(hold_keywords):
             return "HOLD"
         return None
 


### PR DESCRIPTION
## Summary
Investigating #191 ("分析任何一只A股股票,都是提示我买入"). Root cause: `_extract_decision_keyword()` in `tradingagents/graph/signal_processing.py` checks BUY keywords as plain substrings before SELL/HOLD, with no negation awareness. Chinese risk-control conclusions routinely hedge with phrases like "不建议买入" / "暂不建仓" / "不宜建仓" — these contain "买入"/"建仓" and were misclassified as BUY, even though the text explicitly says *not* to buy.

Reproduced directly:
```
最终建议: 不建议买入，维持观望       -> was BUY, should be HOLD
风险大于收益，不宜建仓，建议持有观望  -> was BUY, should be HOLD
核心定性：风险偏高，回避追高，暂不建仓 -> was BUY, should be SELL
```

## Fix
Added a small lookback-window negation check before counting a keyword match (`不`/`非`/`无需`/`别`/`切勿`/`勿`/`避免`/`谨防` immediately preceding the keyword). Kept the existing BUY > SELL > HOLD priority order otherwise — reordering it would just move the bias to a different failure mode (e.g. "谨慎看多...但需回避短期回调风险" would then wrongly become SELL).

Not a full fix for #169 (deepseek), that's a separate, unrelated issue — investigated separately.

## Test plan
- [x] Added `tests/test_signal_processing.py` — 8 cases covering the original bug reports, plain BUY/SELL/HOLD, and a case verifying legitimate bullish-with-caveat text still returns BUY (guards against overcorrecting)
- [x] Ran full existing suite for `signal_processing`/`agent_states`/`trading_graph_multi_horizon` — 25 passed, no regressions