### PR TITLE
feat(llm): add deepseek as a first-class provider

### DIFF
--- a/tests/test_llm_client_factory.py
+++ b/tests/test_llm_client_factory.py
@@ -1,0 +1,24 @@
+"""Tests for tradingagents.llm_clients.factory."""
+
+import pytest
+
+from tradingagents.llm_clients.factory import create_llm_client
+from tradingagents.llm_clients.openai_client import OpenAIClient
+
+
+def test_deepseek_provider_creates_openai_client():
+    client = create_llm_client(provider="deepseek", model="deepseek-chat")
+    assert isinstance(client, OpenAIClient)
+    assert client.provider == "deepseek"
+
+
+def test_deepseek_default_base_url(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    client = create_llm_client(provider="deepseek", model="deepseek-chat")
+    llm = client.get_llm()
+    assert llm.openai_api_base == "https://api.deepseek.com"
+
+
+def test_unsupported_provider_still_raises():
+    with pytest.raises(ValueError, match="Unsupported LLM provider"):
+        create_llm_client(provider="not-a-real-provider", model="foo")

--- a/tradingagents/llm_clients/factory.py
+++ b/tradingagents/llm_clients/factory.py
@@ -15,7 +15,7 @@ def create_llm_client(
     """Create an LLM client for the specified provider.
 
     Args:
-        provider: LLM provider (openai, anthropic, google, xai, ollama, openrouter)
+        provider: LLM provider (openai, anthropic, google, xai, ollama, openrouter, deepseek)
         model: Model name/identifier
         base_url: Optional base URL for API endpoint
         **kwargs: Additional provider-specific arguments
@@ -31,8 +31,8 @@ def create_llm_client(
     if provider_lower in ("openai", "ollama", "openrouter"):
         return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)
 
-    if provider_lower == "xai":
-        return OpenAIClient(model, base_url, provider="xai", **kwargs)
+    if provider_lower in ("xai", "deepseek"):
+        return OpenAIClient(model, base_url, provider=provider_lower, **kwargs)
 
     if provider_lower == "anthropic":
         return AnthropicClient(model, base_url, **kwargs)

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -67,7 +67,7 @@ class UnifiedChatOpenAI(ChatOpenAI):
 
 
 class OpenAIClient(BaseLLMClient):
-    """Client for OpenAI, Ollama, OpenRouter, and xAI providers."""
+    """Client for OpenAI, Ollama, OpenRouter, xAI, and DeepSeek providers."""
 
     def __init__(
         self,
@@ -97,7 +97,8 @@ class OpenAIClient(BaseLLMClient):
         if self.provider == "xai": target_url = "https://api.x.ai/v1"
         elif self.provider == "openrouter": target_url = "https://openrouter.ai/api/v1"
         elif self.provider == "ollama": target_url = "http://localhost:11434/v1"
-        
+        elif self.provider == "deepseek": target_url = "https://api.deepseek.com"
+
         print(f"[LLM Client] Init {self.provider} ({self.model}) at {target_url} (Retries=0, Timeout={llm_kwargs['timeout']}s)")
 
         if self.provider == "xai":
@@ -111,6 +112,10 @@ class OpenAIClient(BaseLLMClient):
         elif self.provider == "ollama":
             llm_kwargs["base_url"] = "http://localhost:11434/v1"
             llm_kwargs["api_key"] = "ollama"
+        elif self.provider == "deepseek":
+            llm_kwargs["base_url"] = self.base_url or "https://api.deepseek.com"
+            api_key = os.environ.get("DEEPSEEK_API_KEY")
+            if api_key: llm_kwargs["api_key"] = api_key
         elif self.base_url:
             llm_kwargs["base_url"] = self.base_url
 


### PR DESCRIPTION
## Summary
Addresses #169 ("不支持deepseek吗"). The reported log shows `Unsupported LLM provider: deepseek` from `create_llm_client()` — setting `TA_LLM_PROVIDER=deepseek` currently hits the factory's fallback `raise ValueError`.

DeepSeek's API is OpenAI-compatible, so this routes `deepseek` through the existing `OpenAIClient` the same way `xai`/`openrouter` already are: default `base_url` to `https://api.deepseek.com`, read the key from `DEEPSEEK_API_KEY`.

Note: a `TA_LLM_PROVIDER=openai` + `TA_BASE_URL=https://api.deepseek.com` workaround already works today without this change, but `deepseek` as an explicit provider name is what users naturally reach for first.

## Test plan
- [x] Added `tests/test_llm_client_factory.py` — 3 cases (client construction, default base_url, unsupported provider still raises)
- [x] Manually constructed a `deepseek` client end-to-end (no live call, no API key available here) and confirmed `base_url`/`model` resolve correctly