### PR TITLE
fix: 线程池饱和 524 修复 + 股票识别兜底 + 错误信息人性化

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import re
+import socket
 import traceback
 from contextlib import asynccontextmanager
 from io import StringIO
@@ -33,7 +34,7 @@ load_dotenv()
 
 from fastapi import FastAPI, File, HTTPException, Depends, Query, Request, UploadFile, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, field_serializer
 from sqlalchemy.orm import Session
@@ -204,6 +205,12 @@ async def _run_manual_trigger(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize resources on startup and cleanup on shutdown."""
+    # 全局 socket 默认超时：akshare 等库内部的 requests 调用不传 timeout，
+    # 网络丢包时 TLS 握手/读会永久阻塞，僵尸线程逐渐占满线程池（见 healthz 探针）。
+    # uvicorn/asyncio 的服务端 socket 显式 setblocking(False)，不受此影响；
+    # httpx/openai SDK 自带超时配置，也不受影响。
+    socket.setdefaulttimeout(float(os.getenv("TA_SOCKET_DEFAULT_TIMEOUT", "60")))
+    _log(f"Global socket default timeout set to {socket.getdefaulttimeout()}s.")
     # Raise the AnyIO thread limiter ceiling so frequent sync endpoints
     # (tracking-board polling, /v1/jobs/{id} polling, akshare-backed
     # market endpoints) cannot starve each other when the event loop is
@@ -223,6 +230,7 @@ async def lifespan(app: FastAPI):
     # default is `min(32, cpu_count + 4)`, which is too small when many
     # `_run_job_inner` coroutines fan out concurrent `to_thread` calls for
     # DB writes, LLM extraction, and akshare data collection.
+    global _default_executor
     new_default_executor: Optional[ThreadPoolExecutor] = None
     try:
         loop = asyncio.get_running_loop()
@@ -232,6 +240,7 @@ async def lifespan(app: FastAPI):
             thread_name_prefix="ta-asyncio",
         )
         loop.set_default_executor(new_default_executor)
+        _default_executor = new_default_executor
         _log(f"Default asyncio executor set to {executor_workers} workers.")
     except Exception as exc:
         _log(f"Could not configure default asyncio executor: {exc}")
@@ -301,6 +310,8 @@ app.add_middleware(
 )
 
 _executor = ThreadPoolExecutor(max_workers=int(os.getenv("TA_MAX_WORKERS", "2")))
+# lifespan 中创建的 asyncio 默认 executor，healthz 探针用它报告饱和度
+_default_executor: Optional[ThreadPoolExecutor] = None
 
 # ── Singleton job store (in-memory or Redis depending on REDIS_URL) ─────────
 _job_store_instance: Optional[Any] = None
@@ -2463,8 +2474,24 @@ async def _stream_job_events(job_id: str):
 
 
 @app.get("/healthz")
-def healthz() -> Dict[str, str]:
-    return {"status": "ok"}
+async def healthz():
+    """健康检查，同时探测 asyncio 默认线程池是否被僵尸线程占满。
+
+    向默认 executor 提交一个 no-op，5 秒内排不上队即判定饱和并返回 503
+    （生产事故：无超时的网络调用把 64 个 worker 全部占死，所有依赖
+    to_thread 的接口静默挂起，前端表现为 Cloudflare 524）。
+    """
+    payload: Dict[str, Any] = {"status": "ok"}
+    if _default_executor is not None:
+        payload["executor_queued"] = _default_executor._work_queue.qsize()
+        payload["executor_threads"] = len(_default_executor._threads)
+    try:
+        loop = asyncio.get_running_loop()
+        await asyncio.wait_for(loop.run_in_executor(None, int), timeout=5)
+    except asyncio.TimeoutError:
+        payload["status"] = "thread_pool_starved"
+        return JSONResponse(status_code=503, content=payload)
+    return payload
 
 
 # Simple in-memory rate limiter for version stats: {ip: last_timestamp}

--- a/api/main.py
+++ b/api/main.py
@@ -2778,6 +2778,9 @@ async def _ai_extract_symbol_and_date_streaming(
     import json as _json
 
     today = datetime.now().strftime("%Y-%m-%d")
+    # 兜底：先用 regex 直接从原文抽 symbol/date，LLM 失败 / 限流 / 返回 null 时
+    # 至少不会把用户已经明确输入的代码也判为"无法识别"。
+    fast_symbol, fast_date = _extract_symbol_and_date(text)
     llm_name: Optional[str] = None
     llm_date: Optional[str] = None
     llm_horizons: List[str] = ["short"]
@@ -2845,20 +2848,29 @@ async def _ai_extract_symbol_and_date_streaming(
         _log(f"[StockExtract streaming] LLM failed: {e}")
 
     if not llm_name:
+        if fast_symbol:
+            _log(f"[StockExtract] LLM 未返回 stock_name，使用 regex 兜底: {fast_symbol}")
+            return fast_symbol, fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
         return None, None, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     _log(f"[StockExtract] extracted name='{llm_name}', date={llm_date}, horizons={llm_horizons}")
-    if re.match(r"^\d{6}$", llm_name) or re.match(r"^[A-Za-z]{1,6}(\.[A-Za-z]+)?$", llm_name):
+    if re.match(r"^\d{6}(?:\.(?:SH|SZ|SS))?$", llm_name, re.IGNORECASE) or re.match(r"^[A-Za-z]{1,6}(\.[A-Za-z]+)?$", llm_name):
         symbol = _normalize_symbol(llm_name)
-        return symbol or None, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
+        if symbol:
+            return symbol, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     local_code = await asyncio.to_thread(_search_cn_stock_by_name, llm_name)
     if local_code:
         return local_code, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     fallback = _normalize_symbol(llm_name)
-    if fallback:
+    if fallback and re.search(r"\d{6}|[A-Za-z]{2,}", fallback):
         return fallback, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
+
+    # 最后兜底：LLM 返回了名字但所有 resolver 都解析不出，且 regex 找到了清晰代码
+    if fast_symbol:
+        _log(f"[StockExtract] LLM 名 '{llm_name}' 无法解析为代码，使用 regex 兜底: {fast_symbol}")
+        return fast_symbol, llm_date or fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     return None, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
@@ -2875,6 +2887,9 @@ def _ai_extract_symbol_and_date(
     import json as _json
 
     today = datetime.now().strftime("%Y-%m-%d")
+    # 兜底：先用 regex 直接从原文抽 symbol/date，LLM 失败 / 限流 / 返回 null 时
+    # 至少不会把用户已经明确输入的代码也判为"无法识别"。
+    fast_symbol, fast_date = _extract_symbol_and_date(text)
 
     llm_name: Optional[str] = None
     llm_date: Optional[str] = None
@@ -2940,16 +2955,20 @@ def _ai_extract_symbol_and_date(
         _log(f"[StockExtract] LLM failed: {e}")
 
     if not llm_name:
+        if fast_symbol:
+            _log(f"[StockExtract] LLM 未返回 stock_name，使用 regex 兜底: {fast_symbol}")
+            return fast_symbol, fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
         _log(f"[StockExtract] LLM returned no stock name for: '{text[:40]}'")
         return None, None, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     _log(f"[StockExtract] LLM extracted name='{llm_name}', date={llm_date}, horizons={llm_horizons}")
 
     # ── Step 2: If looks like a direct code (digits / letters), normalize it ──
-    if re.match(r"^\d{6}$", llm_name) or re.match(r"^[A-Za-z]{1,6}(\.[A-Za-z]+)?$", llm_name):
+    if re.match(r"^\d{6}(?:\.(?:SH|SZ|SS))?$", llm_name, re.IGNORECASE) or re.match(r"^[A-Za-z]{1,6}(\.[A-Za-z]+)?$", llm_name):
         symbol = _normalize_symbol(llm_name)
-        _log(f"[StockExtract] Direct code: {symbol}")
-        return symbol or None, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
+        if symbol:
+            _log(f"[StockExtract] Direct code: {symbol}")
+            return symbol, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     # ── Step 3: Search akshare A-share name database ──────────────────────────
     local_code = _search_cn_stock_by_name(llm_name)
@@ -2958,10 +2977,17 @@ def _ai_extract_symbol_and_date(
         return local_code, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     # ── Step 4: Last resort — treat LLM name as a raw code ────────────────────
+    # _normalize_symbol 在找不到代码时会原样返回，需要校验结果包含数字/英文，
+    # 避免把"天孚通讯"这种纯中文 LLM 输出当成 symbol 透传给 provider。
     fallback = _normalize_symbol(llm_name)
-    if fallback:
+    if fallback and re.search(r"\d{6}|[A-Za-z]{2,}", fallback):
         _log(f"[StockExtract] Fallback normalize: '{llm_name}' → {fallback}")
         return fallback, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
+
+    # 最后兜底：LLM 给了名字但所有 resolver 都解析不出，且 regex 找到了清晰代码
+    if fast_symbol:
+        _log(f"[StockExtract] LLM 名 '{llm_name}' 无法解析为代码，使用 regex 兜底: {fast_symbol}")
+        return fast_symbol, llm_date or fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     _log(f"[StockExtract] Could not resolve '{llm_name}' to a stock code")
     return None, llm_date, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context

--- a/api/main.py
+++ b/api/main.py
@@ -2878,6 +2878,13 @@ async def _ai_extract_symbol_and_date_streaming(
         if fast_symbol:
             _log(f"[StockExtract] LLM 未返回 stock_name，使用 regex 兜底: {fast_symbol}")
             return fast_symbol, fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
+        # LLM 挂掉(限流/模型下线/网络)且原文没有代码时，拿原文在本地股票名单里
+        # 搜一次：_search_cn_stock_by_name 支持"名称是输入子串"的匹配，
+        # "分析一下 飞沃科技" 可以不经 LLM 直接命中 301232.SZ
+        local_code = await asyncio.to_thread(_search_cn_stock_by_name, text)
+        if local_code:
+            _log(f"[StockExtract] LLM 失败，本地名单从原文兜底命中: {local_code}")
+            return local_code, fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
         return None, None, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 
     _log(f"[StockExtract] extracted name='{llm_name}', date={llm_date}, horizons={llm_horizons}")
@@ -2985,6 +2992,11 @@ def _ai_extract_symbol_and_date(
         if fast_symbol:
             _log(f"[StockExtract] LLM 未返回 stock_name，使用 regex 兜底: {fast_symbol}")
             return fast_symbol, fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
+        # LLM 挂掉且原文没有代码时，拿原文在本地股票名单里搜一次（同流式版本）
+        local_code = _search_cn_stock_by_name(text)
+        if local_code:
+            _log(f"[StockExtract] LLM 失败，本地名单从原文兜底命中: {local_code}")
+            return local_code, fast_date or today, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
         _log(f"[StockExtract] LLM returned no stock name for: '{text[:40]}'")
         return None, None, llm_horizons, llm_focus_areas, llm_specific_questions, llm_user_context
 

--- a/api/main.py
+++ b/api/main.py
@@ -2206,7 +2206,7 @@ async def _run_job_inner(
         _log(f"Job completed successfully: {job_id}")
         _log(f"[Timer] TOTAL Job execution (single_horizon) took {time.time() - job_start_t:.2f}s")
     except Exception as exc:
-        err_msg = f"{type(exc).__name__}: {exc}"
+        err_msg = _humanize_analysis_error(f"{type(exc).__name__}: {exc}")
         _set_job(
             job_id,
             status="failed",
@@ -2231,6 +2231,35 @@ async def _run_job_inner(
         )
     finally:
         _shared_data_collector.evict(request.symbol, request.trade_date)
+
+
+_ANALYSIS_ERROR_HINTS: List[tuple] = [
+    (r"Insufficient Balance|Error code: 402",
+     "您配置的大模型 API Key 余额不足。请前往模型服务商充值，或在「设置」中更换其他模型。"),
+    (r"DataInspectionFailed|sensitive words detect|data_inspection",
+     "模型服务商的内容安全审查拦截了本次分析输出（A股分析内容偶发误伤）。请重试一次；若频繁出现，建议在「设置」中更换其他模型服务商。"),
+    (r"Error code: 429|too.?many.?requests|throttling|rate.?limit",
+     "模型服务限流（请求过于频繁或额度受限）。请稍后重试，或在「设置」中更换模型。"),
+    (r"Error code: 401|Authorization Failed|invalid.*api.?key|authentication",
+     "模型 API Key 无效或已过期。请在「设置」中检查 API Key 配置并点击「测试」验证。"),
+    (r"Unsupported model|invalid_parameter.*model|model.*not.*(exist|found)",
+     "配置的模型名称不被服务商支持（可能已下线或改名）。请在「设置」中更换模型名称。"),
+    (r"Error code: 5\d\d|overloaded|InternalError|upload file failed",
+     "模型服务端暂时故障。请稍后重试；若持续失败，建议在「设置」中更换模型。"),
+    (r"Connection error|peer closed connection|Request timed out|timed?.?out|ConnectTimeout|Connection refused",
+     "连接模型服务失败（网络波动或服务不可达）。请稍后重试，并确认「设置」中的 Base URL 可以访问。"),
+]
+
+
+def _humanize_analysis_error(err: str) -> str:
+    """把 LLM/网络的原始报错翻译成用户能看懂的提示与建议动作。
+
+    识别不了的错误原样返回；识别出的保留截断后的原始错误便于反馈排查。
+    """
+    for pat, hint in _ANALYSIS_ERROR_HINTS:
+        if re.search(pat, err, re.IGNORECASE):
+            return f"{hint}\n\n（原始错误：{err[:200]}）"
+    return err
 
 
 def _normalize_symbol(raw: str) -> str:
@@ -3119,7 +3148,7 @@ async def chat_completions(
                 await _run_job(job_id, analyze_req, True, True, current_user.id, "chat")
             except Exception as exc:
                 _log(f"[chat] _extract_and_run failed: {exc}")
-                _emit_job_event(job_id, "job.failed", {"error": str(exc)})
+                _emit_job_event(job_id, "job.failed", {"error": _humanize_analysis_error(str(exc))})
 
         _create_tracked_task(_extract_and_run())
         return StreamingResponse(

--- a/tradingagents/graph/data_collector.py
+++ b/tradingagents/graph/data_collector.py
@@ -1,9 +1,10 @@
 """DataCollector: fetch all data once, serve windowed views to analyst agents."""
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait as futures_wait
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
+import os
 import threading
 import time
 import pandas as pd
@@ -33,6 +34,11 @@ INDICATORS = [
 ]
 SHORT_DAYS = 14
 LONG_DAYS = 90
+
+# 网络丢包时单个数据源可能永久卡死（SSL 握手/读无超时），必须给整轮抓取
+# 设硬上限，否则卡死线程会拿着 per-key 锁把后续同标的分析全部拖死，
+# 并逐渐占满 asyncio 默认线程池（生产事故：64/64 全部僵死 → 前端 524）。
+FETCH_ALL_TIMEOUT = int(os.getenv("TA_DATA_FETCH_TIMEOUT", "300"))
 
 import numpy as np
 
@@ -290,10 +296,19 @@ def _fetch_all(ticker: str, trade_date: str) -> Dict[str, Any]:
     results: Dict[str, Any] = {}
     fetch_start = time.time()
     # 减少并发池大小，避免被反爬
-    with ThreadPoolExecutor(max_workers=min(10, len(tasks))) as executor:
+    executor = ThreadPoolExecutor(max_workers=min(10, len(tasks)))
+    try:
         future_to_key = {executor.submit(_safe, tool, payload): key for key, (tool, payload) in tasks.items()}
-        for future in future_to_key:
+        done, not_done = futures_wait(set(future_to_key), timeout=FETCH_ALL_TIMEOUT)
+        for future in done:
             results[future_to_key[future]] = future.result()
+        for future in not_done:
+            key = future_to_key[future]
+            results[key] = f"{key} 数据拉取超时（>{FETCH_ALL_TIMEOUT}s），本次分析跳过该数据源"
+            print(f"  [Warning] {key} fetch timed out after {FETCH_ALL_TIMEOUT}s, skipped")
+    finally:
+        # wait=False：卡死的抓取线程留给 socket 超时自行了断，绝不反过来堵住本线程
+        executor.shutdown(wait=False, cancel_futures=True)
 
     # ── Parse CSV once, reuse for indicators and VPA ──────────────────
     raw_csv = results.get("stock_data", "")
@@ -371,10 +386,19 @@ class DataCollector:
         """
         key = make_cache_key(ticker, trade_date)
         key_lock = self._get_key_lock(key)
-        with key_lock:
+        # 带超时的 acquire：即使持锁的抓取意外卡死，排队者也能在有限时间内
+        # 报错退出，而不是把线程池 worker 一个个吸进来陪葬
+        if not key_lock.acquire(timeout=FETCH_ALL_TIMEOUT + 60):
+            raise TimeoutError(
+                f"等待 {key} 数据抓取锁超时（>{FETCH_ALL_TIMEOUT + 60}s），"
+                "可能存在卡死的抓取任务，本次分析中止"
+            )
+        try:
             if key not in self._cache:
                 self._cache[key] = _fetch_all(ticker, trade_date)
-        return self._cache[key]
+            return self._cache[key]
+        finally:
+            key_lock.release()
 
     def get(self, ticker: str, trade_date: str) -> Optional[Dict[str, Any]]:
         """Retrieve cached pool, or None if not collected yet."""


### PR DESCRIPTION
本 PR 汇总 v0.8.1-rc1~rc4 的四个修复,均已在生产验证:

## 1. 线程池饱和导致分析请求 524 卡死(rc2,核心修复)
py-spy 实锤:asyncio 默认线程池 64 worker 被无超时网络调用的僵尸线程全部占满(23 卡 SSL 握手、10 卡 SSL 读、15 等锁、16 等 future),chat/analyze 在返回响应前的 to_thread 永远排队 → Cloudflare 524 → 前端 Failed to fetch。该问题从 4 月中旬起累计产生 13 条用户反馈。

三层防御:
- `socket.setdefaulttimeout(60)`:akshare 等库内 1200+ 处不带 timeout 的 requests 调用不再永久阻塞
- `_fetch_all` 整轮抓取 300s 硬上限 + `shutdown(wait=False, cancel_futures=True)`;per-key 锁改带超时 acquire,防锁 convoy
- `/healthz` 增加线程池饱和探针,5s 排不上队返回 503

## 2. 股票代码提取兜底(rc1+rc3)
- LLM 失败/限流时 regex 兜底,不再误判"无法识别"(rc1)
- LLM 挂掉且无代码时,原文直查本地股票名单,'分析一下 飞沃科技'可不经 LLM 命中 301232.SZ(rc3)

## 3. 分析失败错误信息人性化(rc4)
402 欠费/429 限流/内容审查/连接失败/模型下线等翻译为中文提示+建议动作,覆盖近 14 天全部高频生产错误样本。

https://claude.ai/code/session_01BkzX3yLYxeGcG1dxGJFmN5