### PR TITLE
fix: 长时分析超过软超时后继续执行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ TA_LLM_DEEP=gpt-4o
 # TA_MAX_DEBATE=1
 # TA_MAX_RISK=1
 
+# 长任务软提醒与硬终止上限（秒）；0 表示禁用对应期限
+# 默认运行 30 分钟后提示仍在继续，最长 2 小时后终止以释放调度资源
+# TA_JOB_TIMEOUT=1800
+# TA_JOB_HARD_TIMEOUT=7200
+
 # --- VLM 截图识别 (Vision Language Model) ---
 # 用于持仓截图识别，默认使用智谱 glm-4.6v-flash（免费）
 # TA_VLM_API_KEY=你的智谱API Key

--- a/api/job_store_redis.py
+++ b/api/job_store_redis.py
@@ -32,7 +32,7 @@ def _serialize_value(v: Any) -> str:
     """Serialize a Python value for storage in a Redis Hash field."""
     if v is None:
         return ""
-    if isinstance(v, (dict, list)):
+    if isinstance(v, (dict, list, bool)):
         return json.dumps(v, ensure_ascii=False)
     return str(v)
 
@@ -78,7 +78,7 @@ class RedisJobStore:
     def set_job(self, job_id: str, **fields: Any) -> None:
         """Create or update job fields (merge semantics).
 
-        Complex values (dict/list) are JSON-serialized; None becomes empty string.
+        Complex values and booleans are JSON-serialized; None becomes empty string.
         Each call refreshes the TTL.
         """
         if not fields:

--- a/api/main.py
+++ b/api/main.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from threading import Lock
 from fastapi import Body
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 from uuid import uuid4
 
 import logging
@@ -345,7 +345,11 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-_JOB_TIMEOUT = int(os.getenv("TA_JOB_TIMEOUT", "1800"))  # seconds (默认 30 分钟，适配多 Agent 长流程分析)
+# Soft deadline for long-running analyses.  This keeps the historical
+# TA_JOB_TIMEOUT setting API-compatible, but crossing it is now an overtime
+# notification rather than a terminal failure: the actual workflow continues
+# until it completes or raises a real exception.
+_JOB_TIMEOUT = int(os.getenv("TA_JOB_TIMEOUT", "1800"))
 def _create_tracked_task(coro, *, label: str = "Background task") -> asyncio.Task:
     """Create an asyncio task and keep a reference to prevent GC.
     Also logs unhandled exceptions via a done callback."""
@@ -641,6 +645,8 @@ class JobStatusResponse(BaseModel):
     symbol: str
     trade_date: str
     error: Optional[str] = None
+    overtime: bool = False
+    overtime_at: Optional[str] = None
     waiting_ahead_count: Optional[int] = None
     scheduled_running_count: Optional[int] = None
     scheduled_concurrency_limit: Optional[int] = None
@@ -1555,29 +1561,77 @@ async def _run_job(
     user_id: Optional[str] = None,
     request_source: str = "api",
 ) -> None:
-    # 用 asyncio.Task + sleep 竞速代替 wait_for，避免 cancel 卡在 to_thread 导致
-    # semaphore 永远不释放的问题。超时后标记失败但不 cancel 内部协程（让线程自然结束）。
+    # Keep the workflow in its own task so crossing the soft deadline does not
+    # cancel to_thread work.  TA_JOB_TIMEOUT is intentionally a warning only;
+    # the wrapper remains attached and awaits the real terminal outcome.
     inner_task = asyncio.create_task(
         _run_job_inner(job_id, request, stream_events, save_report, user_id, request_source)
     )
-    done, _ = await asyncio.wait({inner_task}, timeout=_JOB_TIMEOUT)
-    if inner_task in done:
-        # 正常完成（可能成功也可能异常）
-        if not inner_task.cancelled() and inner_task.exception():
-            _log(f"[Job {job_id}] failed: {inner_task.exception()}")
-        return
-    # 超时：标记失败，但不 cancel 内部 task（避免 cancel 卡住）
-    err_msg = f"任务超时（超过 {_JOB_TIMEOUT} 秒），已自动终止"
-    _log(f"[Job {job_id}] {err_msg}")
-    _set_job(job_id, status="failed", error=err_msg, finished_at=_utcnow_iso())
-    # 注意：不能用 asyncio.to_thread 写 DB，因为线程池可能被僵尸任务占满导致死锁。
-    # 用同步方式直接写，SQLite 的写入足够快不会阻塞事件循环。
     try:
-        with get_db_ctx() as db:
-            report_service.mark_report_failed(db, job_id, err_msg)
-    except Exception:
-        pass
-    _emit_job_event(job_id, "job.failed", {"job_id": job_id, "error": err_msg})
+        if _JOB_TIMEOUT > 0:
+            done, _ = await asyncio.wait({inner_task}, timeout=_JOB_TIMEOUT)
+            if inner_task not in done:
+                overtime_at = _utcnow_iso()
+                message = f"任务已运行超过 {_JOB_TIMEOUT} 秒，后台仍在继续"
+                _log(f"[Job {job_id}] {message}")
+                _set_job(
+                    job_id,
+                    status="running",
+                    overtime=True,
+                    overtime_at=overtime_at,
+                    error=None,
+                )
+                _emit_job_event(
+                    job_id,
+                    "job.overtime",
+                    {
+                        "job_id": job_id,
+                        "elapsed_seconds": _JOB_TIMEOUT,
+                        "overtime_at": overtime_at,
+                        "message": message,
+                    },
+                )
+
+        await inner_task
+    except asyncio.CancelledError:
+        # Preserve normal application shutdown/caller cancellation semantics.
+        if not inner_task.done():
+            inner_task.cancel()
+        raise
+    except Exception as exc:
+        # _run_job_inner handles expected workflow errors itself.  This guards
+        # failures before its try block (initialisation/configuration) as well.
+        err_msg = f"{type(exc).__name__}: {exc}"
+        _log(f"[Job {job_id}] failed: {err_msg}")
+        _set_job(
+            job_id,
+            status="failed",
+            error=err_msg,
+            overtime=False,
+            overtime_at=None,
+            finished_at=_utcnow_iso(),
+        )
+        try:
+            with get_db_ctx() as db:
+                report_service.mark_report_failed(db, job_id, err_msg)
+        except Exception:
+            pass
+        _emit_job_event(job_id, "job.failed", {"job_id": job_id, "error": err_msg})
+
+
+async def _save_report_or_raise(
+    job_id: str,
+    save_callable: Callable[[], Any],
+    *,
+    stage: str,
+) -> None:
+    """Run a report DB finalizer without turning persistence errors into success."""
+    try:
+        await asyncio.to_thread(save_callable)
+    except Exception as exc:
+        message = f"Failed to {stage} report for job {job_id}: {exc}"
+        _log(message)
+        raise RuntimeError(message) from exc
 
 
 async def _run_job_inner(
@@ -1612,7 +1666,13 @@ async def _run_job_inner(
 
     config = await asyncio.to_thread(_init_and_configure)
 
-    _set_job(job_id, status="running", started_at=_utcnow_iso(), symbol=normalized_symbol)
+    _set_job(
+        job_id,
+        status="running",
+        started_at=_utcnow_iso(),
+        symbol=normalized_symbol,
+        error=None,
+    )
 
     _emit_job_event(
         job_id,
@@ -1646,6 +1706,9 @@ async def _run_job_inner(
                 status="completed",
                 result=result,
                 decision="DRY_RUN",
+                error=None,
+                overtime=False,
+                overtime_at=None,
                 finished_at=_utcnow_iso(),
             )
             _emit_job_event(
@@ -1938,14 +2001,13 @@ async def _run_job_inner(
                         )
                         save_db.commit()
 
-                try:
-                    await asyncio.to_thread(_save_report_sync)
-                except Exception as e:
-                    _log(f"Failed to save report: {e}")
+                await _save_report_or_raise(job_id, _save_report_sync, stage="save")
 
             # 所有后处理完成后再标记 completed，防止 SSE 超时提前关闭流
             _set_job(job_id, status="completed", result=result,
-                     decision=decision, finished_at=_utcnow_iso())
+                     decision=decision, error=None, overtime=False,
+                     overtime_at=None,
+                     finished_at=_utcnow_iso())
             _emit_job_event(job_id, "job.completed", {
                 "job_id": job_id, "decision": decision,
                 "direction": result["direction"],
@@ -2176,16 +2238,16 @@ async def _run_job_inner(
                     )
                     save_db.commit()
 
-            try:
-                await asyncio.to_thread(_save_report_final_sync)
-            except Exception as e:
-                _log(f"Failed to finalize report: {e}")
+            await _save_report_or_raise(job_id, _save_report_final_sync, stage="finalize")
         # 所有后处理完成后再标记 completed，防止 SSE 超时提前关闭流
         _set_job(
             job_id,
             status="completed",
             result=result,
             decision=decision,
+            error=None,
+            overtime=False,
+            overtime_at=None,
             finished_at=_utcnow_iso(),
         )
         _emit_job_event(
@@ -2211,6 +2273,8 @@ async def _run_job_inner(
             job_id,
             status="failed",
             error=err_msg,
+            overtime=False,
+            overtime_at=None,
             traceback=traceback.format_exc(),
             finished_at=_utcnow_iso(),
         )
@@ -2755,6 +2819,8 @@ async def analyze(
         symbol=request.symbol,
         trade_date=request.trade_date,
         error=None,
+        overtime=False,
+        overtime_at=None,
         result=None,
         decision=None,
     )
@@ -2793,6 +2859,8 @@ def get_job_status(job_id: str, current_user: UserDB = Depends(_require_api_user
         symbol=job["symbol"],
         trade_date=job["trade_date"],
         error=job.get("error"),
+        overtime=bool(job.get("overtime", False)),
+        overtime_at=job.get("overtime_at"),
         waiting_ahead_count=job.get("waiting_ahead_count"),
         scheduled_running_count=job.get("scheduled_running_count"),
         scheduled_concurrency_limit=job.get("scheduled_concurrency_limit"),

--- a/api/main.py
+++ b/api/main.py
@@ -1570,7 +1570,7 @@ async def _run_job(
     try:
         if _JOB_TIMEOUT > 0:
             done, _ = await asyncio.wait({inner_task}, timeout=_JOB_TIMEOUT)
-            if inner_task not in done:
+            if inner_task not in done and not inner_task.done():
                 overtime_at = _utcnow_iso()
                 message = f"任务已运行超过 {_JOB_TIMEOUT} 秒，后台仍在继续"
                 _log(f"[Job {job_id}] {message}")

--- a/api/main.py
+++ b/api/main.py
@@ -347,9 +347,13 @@ def _utcnow_iso() -> str:
 
 # Soft deadline for long-running analyses.  This keeps the historical
 # TA_JOB_TIMEOUT setting API-compatible, but crossing it is now an overtime
-# notification rather than a terminal failure: the actual workflow continues
-# until it completes or raises a real exception.
+# notification rather than a terminal failure.  TA_JOB_HARD_TIMEOUT is the
+# resource-safety backstop that releases scheduler capacity if a workflow is
+# genuinely wedged.  Set either value to 0 to disable that deadline.
 _JOB_TIMEOUT = int(os.getenv("TA_JOB_TIMEOUT", "1800"))
+_JOB_HARD_TIMEOUT = int(os.getenv("TA_JOB_HARD_TIMEOUT", "7200"))
+
+
 def _create_tracked_task(coro, *, label: str = "Background task") -> asyncio.Task:
     """Create an asyncio task and keep a reference to prevent GC.
     Also logs unhandled exceptions via a done callback."""
@@ -1562,35 +1566,93 @@ async def _run_job(
     request_source: str = "api",
 ) -> None:
     # Keep the workflow in its own task so crossing the soft deadline does not
-    # cancel to_thread work.  TA_JOB_TIMEOUT is intentionally a warning only;
-    # the wrapper remains attached and awaits the real terminal outcome.
+    # cancel to_thread work.  The hard deadline cancels the coroutine and
+    # releases its caller/scheduler slot.  A sync function already submitted by
+    # asyncio.to_thread may finish later, but cancellation prevents the
+    # coroutine from resuming into report or terminal-state writes.
+    started_monotonic = time.monotonic()
     inner_task = asyncio.create_task(
         _run_job_inner(job_id, request, stream_events, save_report, user_id, request_source)
     )
     try:
         if _JOB_TIMEOUT > 0:
-            done, _ = await asyncio.wait({inner_task}, timeout=_JOB_TIMEOUT)
+            soft_wait_seconds = _JOB_TIMEOUT
+            if _JOB_HARD_TIMEOUT > 0:
+                soft_wait_seconds = min(soft_wait_seconds, _JOB_HARD_TIMEOUT)
+            done, _ = await asyncio.wait({inner_task}, timeout=soft_wait_seconds)
             if inner_task not in done and not inner_task.done():
-                overtime_at = _utcnow_iso()
-                message = f"任务已运行超过 {_JOB_TIMEOUT} 秒，后台仍在继续"
-                _log(f"[Job {job_id}] {message}")
+                # When the configured hard limit is no greater than the soft
+                # limit, skip the misleading overtime notice and fall through
+                # to the terminal hard-limit handling below.
+                if _JOB_HARD_TIMEOUT <= 0 or _JOB_TIMEOUT < _JOB_HARD_TIMEOUT:
+                    overtime_at = _utcnow_iso()
+                    elapsed_seconds = time.monotonic() - started_monotonic
+                    message = (
+                        f"分析耗时较长（已超过 {_JOB_TIMEOUT} 秒），后台仍在继续，"
+                        "正在等待最终结果，请勿重复提交。"
+                    )
+                    _log(f"[Job {job_id}] {message}")
+                    _set_job(
+                        job_id,
+                        status="running",
+                        overtime=True,
+                        overtime_at=overtime_at,
+                        error=None,
+                    )
+                    _emit_job_event(
+                        job_id,
+                        "job.overtime",
+                        {
+                            "job_id": job_id,
+                            "elapsed_seconds": elapsed_seconds,
+                            "soft_timeout_seconds": _JOB_TIMEOUT,
+                            "overtime_at": overtime_at,
+                            "message": message,
+                        },
+                    )
+
+        if _JOB_HARD_TIMEOUT > 0 and not inner_task.done():
+            remaining_seconds = max(
+                0.0,
+                _JOB_HARD_TIMEOUT - (time.monotonic() - started_monotonic),
+            )
+            done, _ = await asyncio.wait({inner_task}, timeout=remaining_seconds)
+            if inner_task not in done and not inner_task.done() and inner_task.cancel():
+                try:
+                    await inner_task
+                except asyncio.CancelledError:
+                    pass
+
+                elapsed_seconds = time.monotonic() - started_monotonic
+                err_msg = (
+                    f"任务达到硬性运行上限（{_JOB_HARD_TIMEOUT} 秒），已终止。"
+                    "请检查模型或数据源的请求超时配置后重试。"
+                )
+                _log(f"[Job {job_id}] {err_msg}")
                 _set_job(
                     job_id,
-                    status="running",
-                    overtime=True,
-                    overtime_at=overtime_at,
-                    error=None,
+                    status="failed",
+                    error=err_msg,
+                    overtime=False,
+                    overtime_at=None,
+                    finished_at=_utcnow_iso(),
                 )
+                try:
+                    with get_db_ctx() as db:
+                        report_service.mark_report_failed(db, job_id, err_msg)
+                except Exception:
+                    pass
                 _emit_job_event(
                     job_id,
-                    "job.overtime",
+                    "job.failed",
                     {
                         "job_id": job_id,
-                        "elapsed_seconds": _JOB_TIMEOUT,
-                        "overtime_at": overtime_at,
-                        "message": message,
+                        "error": err_msg,
+                        "elapsed_seconds": elapsed_seconds,
+                        "hard_timeout_seconds": _JOB_HARD_TIMEOUT,
                     },
                 )
+                return
 
         await inner_task
     except asyncio.CancelledError:

--- a/api/services/report_service.py
+++ b/api/services/report_service.py
@@ -402,6 +402,9 @@ def create_report(
     if db_report:
         # Update existing
         db_report.status = "completed"
+        # A report may previously have been marked failed by an older worker
+        # or timeout policy.  Successful finalisation is authoritative.
+        db_report.error = None
         db_report.decision = decision
         db_report.direction = resolved["direction"]
         db_report.confidence = resolved["confidence"]

--- a/frontend/src/components/ChatCopilotPanel.tsx
+++ b/frontend/src/components/ChatCopilotPanel.tsx
@@ -9,6 +9,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { api } from '@/services/api'
 import { useAnalysisStore } from '@/stores/analysisStore'
+import { classifyRecoveredJobStatus, getJobLifecycleUpdate } from '@/utils/jobLifecycle'
 import type {
     AgentReportEvent,
     AgentSnapshotEvent,
@@ -156,17 +157,20 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
     const firstTokenMapRef = useRef<Record<string, boolean>>({})
     const sectionToMsgIdsRef = useRef<Record<string, string[]>>({}) // section → all agent bubble msgIds
     const typingIndicatorIdRef = useRef<string | null>(null)
+    const recoveryAbortRef = useRef<AbortController | null>(null)
     const messagesEndRef = useRef<HTMLDivElement>(null)
     const messagesContainerRef = useRef<HTMLDivElement>(null)
 
     const {
         chatMessages,
         isAnalyzing,
+        analysisOvertimeNotice,
         setCurrentJobId,
         setCurrentSymbol,
         setIsAnalyzing,
         setIsConnected,
         setAnalysisRunState,
+        setAnalysisOvertimeNotice,
         setCurrentHorizon,
         updateAgentStatus,
         updateAgentSnapshot,
@@ -184,58 +188,98 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
         reset,
     } = useAnalysisStore()
 
-    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+    const sleepUntilRetry = (ms: number, signal: AbortSignal) => new Promise<boolean>(resolve => {
+        if (signal.aborted) {
+            resolve(false)
+            return
+        }
+        const timer = window.setTimeout(() => {
+            signal.removeEventListener('abort', onAbort)
+            resolve(true)
+        }, ms)
+        const onAbort = () => {
+            window.clearTimeout(timer)
+            resolve(false)
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+    })
 
-    const recoverInterruptedJob = async () => {
+    const recoverInterruptedJob = async (signal: AbortSignal) => {
         const { currentJobId } = useAnalysisStore.getState()
         if (!currentJobId) return false
 
         pushSystem(`分析流中断，正在回查任务状态：${currentJobId}`)
+        setIsConnected(false)
+        setIsAnalyzing(true)
+        setAnalysisRunState('running')
 
-        for (let attempt = 0; attempt < 8; attempt += 1) {
-            const status = await api.getJobStatus(currentJobId)
+        while (!signal.aborted) {
+            try {
+                const status = await api.getJobStatus(currentJobId)
+                if (signal.aborted) return false
+                const disposition = classifyRecoveredJobStatus(status.status, status.error)
 
-            if (status.status === 'completed') {
-                const result = await api.getJobResult(currentJobId)
-                setReport(result.result)
+                if (disposition === 'completed') {
+                    const result = await api.getJobResult(currentJobId)
+                    if (signal.aborted) return false
+                    setReport(result.result)
 
-                const symbol = result.result.symbol
-                const tradeDate = result.result.trade_date
-                if (symbol) {
-                    setCurrentSymbol(symbol)
-                    onSymbolDetected(symbol)
-                }
-
-                try {
-                    const history = await api.getReports(symbol, 0, 10)
-                    const matched = history.reports.find((item: Report) => item.trade_date === tradeDate) ?? history.reports[0]
-                    if (matched) {
-                        setStructuredData({
-                            riskItems: matched.risk_items,
-                            keyMetrics: matched.key_metrics,
-                            confidence: matched.confidence,
-                            targetPrice: matched.target_price,
-                            stopLoss: matched.stop_loss_price,
-                        })
+                    const symbol = result.result.symbol
+                    const tradeDate = result.result.trade_date
+                    if (symbol) {
+                        setCurrentSymbol(symbol)
+                        onSymbolDetected(symbol)
                     }
-                } catch {
-                    // 历史报告回填失败时，至少保留主报告正文
+
+                    try {
+                        const history = await api.getReports(symbol, 0, 10)
+                        const matched = history.reports.find((item: Report) => item.trade_date === tradeDate) ?? history.reports[0]
+                        if (matched) {
+                            setStructuredData({
+                                riskItems: matched.risk_items,
+                                keyMetrics: matched.key_metrics,
+                                confidence: matched.confidence,
+                                targetPrice: matched.target_price,
+                                stopLoss: matched.stop_loss_price,
+                            })
+                        }
+                    } catch {
+                        // 历史报告回填失败时，至少保留主报告正文
+                    }
+
+                    pendingAgentMsgIdsRef.current = new Set()
+                    forceUpdate(n => n + 1)
+                    markAgentMessagesComplete()
+                    pushAssistant(
+                        `**分析完成（已从中断连接恢复）**\n\n方向倾向：**${String(result.result.direction || '未知')}**\n\n执行动作：**${String(result.decision || 'HOLD')}**\n\n> 免责声明：以上内容由模型基于公开数据与规则生成，仅供研究参考，不构成任何投资建议或收益承诺。`
+                    )
+                    setCurrentHorizon(null)
+                    setIsAnalyzing(false)
+                    setAnalysisRunState('completed')
+                    return true
                 }
 
-                pushAssistant(
-                    `**分析完成（已从中断连接恢复）**\n\n方向倾向：**${String(result.result.direction || '未知')}**\n\n执行动作：**${String(result.decision || 'HOLD')}**\n\n> 免责声明：以上内容由模型基于公开数据与规则生成，仅供研究参考，不构成任何投资建议或收益承诺。`
-                )
-                setAnalysisRunState('completed')
-                return true
+                if (disposition === 'failed') {
+                    pushAssistant(`分析失败：${status.error || 'unknown error'}`)
+                    setCurrentHorizon(null)
+                    setIsAnalyzing(false)
+                    setAnalysisRunState('failed', status.error || 'unknown error')
+                    return true
+                }
+
+                if (status.overtime || status.status === 'failed') {
+                    setAnalysisOvertimeNotice(
+                        status.overtime
+                            ? '分析耗时较长，后台仍在继续，正在等待最终结果。'
+                            : '分析已超过旧版服务的时间阈值，但后台仍在继续，正在等待最终结果。',
+                    )
+                }
+            } catch (error) {
+                if (signal.aborted) return false
+                console.warn('任务状态回查失败，将继续重试:', error)
             }
 
-            if (status.status === 'failed') {
-                pushAssistant(`分析失败：${status.error || 'unknown error'}`)
-                setAnalysisRunState('failed', status.error || 'unknown error')
-                return true
-            }
-
-            await sleep(1500)
+            if (!await sleepUntilRetry(3000, signal)) return false
         }
 
         return false
@@ -249,6 +293,10 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
             behavior: 'smooth',
         })
     }, [chatMessages])
+
+    useEffect(() => () => {
+        recoveryAbortRef.current?.abort()
+    }, [])
 
     const pushAssistant = (content: string) => {
         addChatMessage({
@@ -270,9 +318,20 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
 
     const parseAndDispatch = (event: StreamEvent) => {
         const { event: eventName, data } = event
+        const lifecycleUpdate = getJobLifecycleUpdate(eventName, data)
+        if (lifecycleUpdate) {
+            setIsAnalyzing(lifecycleUpdate.isAnalyzing)
+            setAnalysisRunState(
+                lifecycleUpdate.runState,
+                eventName === 'job.failed' ? String(data.error || 'unknown error') : null,
+            )
+            setAnalysisOvertimeNotice(lifecycleUpdate.overtimeNotice)
+        }
+
         switch (eventName) {
             case 'job.ready':
                 setIsConnected(true)
+                if (data.job_id) setCurrentJobId(String(data.job_id))
                 // 把 typing indicator 换成"解析中"提示，告知用户正在识别标的
                 if (typingIndicatorIdRef.current) {
                     setMessageContent(typingIndicatorIdRef.current, '__parsing__')
@@ -298,12 +357,13 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 break
             }
             case 'job.running':
-                setIsAnalyzing(true)
-                setAnalysisRunState('running')
                 // 切换 indicator 到"分析启动"阶段
                 if (typingIndicatorIdRef.current) {
                     setMessageContent(typingIndicatorIdRef.current, '__status:analyzing__')
                 }
+                break
+            case 'job.overtime':
+                // Soft timeout: keep the stream, progress and running state intact.
                 break
             case 'agent.horizon_start': {
                 const h = String(data.horizon || '')
@@ -315,8 +375,6 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 break
             case 'job.completed': {
                 setCurrentHorizon(null)
-                setIsAnalyzing(false)
-                setAnalysisRunState('completed')
                 // 任务结束：所有 agent 消息标记为已完成（持久化到 store）
                 pendingAgentMsgIdsRef.current = new Set()
                 forceUpdate(n => n + 1)
@@ -348,9 +406,10 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 break
             }
             case 'job.failed':
+                if (classifyRecoveredJobStatus('failed', typeof data.error === 'string' ? data.error : null) === 'running') {
+                    break
+                }
                 setCurrentHorizon(null)
-                setIsAnalyzing(false)
-                setAnalysisRunState('failed', String(data.error || 'unknown error'))
                 pushAssistant(`分析失败：${String(data.error || 'unknown error')}`)
                 break
             case 'agent.status': {
@@ -560,6 +619,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
         const decoder = new TextDecoder()
         let buffer = ''
         let currentEvent = 'message'
+        let terminalReceived = false
 
         while (true) {
             const { value, done } = await reader.read()
@@ -582,8 +642,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 if (!dataLine) continue
                 if (dataLine === '[DONE]' || currentEvent === 'done') {
                     setIsConnected(false)
-                    setIsAnalyzing(false)
-                    return
+                    return terminalReceived
                 }
                 
                 if (currentEvent === 'ping') {
@@ -593,6 +652,15 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 try {
                     const data = JSON.parse(dataLine) as Record<string, unknown>
                     parseAndDispatch({ event: currentEvent, data })
+                    if (
+                        currentEvent === 'job.completed' ||
+                        (currentEvent === 'job.failed' && classifyRecoveredJobStatus(
+                            'failed',
+                            typeof data.error === 'string' ? data.error : null,
+                        ) === 'failed')
+                    ) {
+                        terminalReceived = true
+                    }
                 } catch {
                     console.error('SSE解析失败:', dataLine.slice(0, 120))
                 }
@@ -600,13 +668,13 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
         }
 
         setIsConnected(false)
-        setIsAnalyzing(false)
+        return terminalReceived
     }
 
     const handleSubmit = async (e: FormEvent) => {
         e.preventDefault()
         const prompt = input.trim()
-        if (!prompt || streaming) return
+        if (!prompt || streaming || isAnalyzing) return
 
         // Inject custom analysis prompt from settings if set
         const customPrompt = localStorage.getItem('ta-custom-prompt')?.trim() || ''
@@ -638,9 +706,20 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
         setIsAnalyzing(true)
         setIsConnected(false)
         setAnalysisRunState('running')
+        recoveryAbortRef.current?.abort()
+        const recoveryController = new AbortController()
+        recoveryAbortRef.current = recoveryController
 
         try {
-            await streamChat(fullPrompt)
+            const terminalReceived = await streamChat(fullPrompt)
+            if (!terminalReceived) {
+                const recovered = await recoverInterruptedJob(recoveryController.signal)
+                if (!recovered && !recoveryController.signal.aborted) {
+                    setIsAnalyzing(false)
+                    setAnalysisRunState('failed', '分析流在任务编号返回前中断')
+                    pushAssistant('请求中断：未能取得任务编号，无法继续回查任务状态。')
+                }
+            }
         } catch (error) {
             // 出错时清理 typing indicator
             if (typingIndicatorIdRef.current) {
@@ -650,20 +729,25 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 typingIndicatorIdRef.current = null
             }
             const errorMessage = error instanceof Error ? error.message : 'unknown error'
-            const shouldRecover = /network|fetch|stream|sse|body/i.test(errorMessage)
-            if (shouldRecover) {
-                const recovered = await recoverInterruptedJob()
+            const canRecover = Boolean(useAnalysisStore.getState().currentJobId)
+            if (canRecover) {
+                const recovered = await recoverInterruptedJob(recoveryController.signal)
                 if (!recovered) {
-                    setAnalysisRunState('failed', errorMessage)
-                    pushAssistant(`请求中断：${errorMessage}\n\n后端任务可能仍在执行，请稍后到历史报告中查看结果。`)
+                    if (!recoveryController.signal.aborted) {
+                        setAnalysisRunState('failed', errorMessage)
+                        pushAssistant(`请求中断：${errorMessage}\n\n后端任务可能仍在执行，请稍后到历史报告中查看结果。`)
+                    }
                 }
             } else {
+                setIsAnalyzing(false)
                 setAnalysisRunState('failed', errorMessage)
                 pushAssistant(`请求失败：${errorMessage}`)
             }
-            setIsAnalyzing(false)
             setIsConnected(false)
         } finally {
+            if (recoveryAbortRef.current === recoveryController) {
+                recoveryAbortRef.current = null
+            }
             setStreaming(false)
         }
     }
@@ -725,6 +809,16 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                     </button>
                 ))}
             </div>
+
+            {analysisOvertimeNotice && (
+                <div
+                    role="status"
+                    className="mb-3 flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-300"
+                >
+                    <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />
+                    <span>{analysisOvertimeNotice}</span>
+                </div>
+            )}
 
             {/* 聊天内容 */}
             <div ref={messagesContainerRef} className="flex-1 min-h-0 overflow-y-auto space-y-2 pr-1">
@@ -936,7 +1030,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                     />
                     <button
                         type="submit"
-                        disabled={!input.trim() || streaming}
+                        disabled={!input.trim() || streaming || isAnalyzing}
                         className="btn-primary px-3 py-2 inline-flex items-center gap-1"
                     >
                         <Send className="w-4 h-4" />

--- a/frontend/src/components/ChatCopilotPanel.tsx
+++ b/frontend/src/components/ChatCopilotPanel.tsx
@@ -9,7 +9,13 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { api } from '@/services/api'
 import { useAnalysisStore } from '@/stores/analysisStore'
-import { classifyRecoveredJobStatus, getJobLifecycleUpdate } from '@/utils/jobLifecycle'
+import {
+    classifyRecoveredJobStatus,
+    DEFAULT_OVERTIME_NOTICE,
+    getJobLifecycleUpdate,
+    hasRecoveryPollingReachedLimit,
+    RECOVERY_POLL_TIMEOUT_MESSAGE,
+} from '@/utils/jobLifecycle'
 import type {
     AgentReportEvent,
     AgentSnapshotEvent,
@@ -207,6 +213,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
     const recoverInterruptedJob = async (signal: AbortSignal) => {
         const { currentJobId } = useAnalysisStore.getState()
         if (!currentJobId) return false
+        let recoveryPollAttempts = 0
 
         pushSystem(`分析流中断，正在回查任务状态：${currentJobId}`)
         setIsConnected(false)
@@ -214,6 +221,15 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
         setAnalysisRunState('running')
 
         while (!signal.aborted) {
+            if (hasRecoveryPollingReachedLimit(recoveryPollAttempts)) {
+                pushAssistant(RECOVERY_POLL_TIMEOUT_MESSAGE)
+                setCurrentHorizon(null)
+                setIsAnalyzing(false)
+                setAnalysisRunState('failed', RECOVERY_POLL_TIMEOUT_MESSAGE)
+                return true
+            }
+            recoveryPollAttempts += 1
+
             try {
                 const status = await api.getJobStatus(currentJobId)
                 if (signal.aborted) return false
@@ -268,11 +284,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 }
 
                 if (status.overtime || status.status === 'failed') {
-                    setAnalysisOvertimeNotice(
-                        status.overtime
-                            ? '分析耗时较长，后台仍在继续，正在等待最终结果。'
-                            : '分析已超过旧版服务的时间阈值，但后台仍在继续，正在等待最终结果。',
-                    )
+                    setAnalysisOvertimeNotice(DEFAULT_OVERTIME_NOTICE)
                 }
             } catch (error) {
                 if (signal.aborted) return false
@@ -734,6 +746,7 @@ export default function ChatCopilotPanel({ onSymbolDetected, onShowReport, initi
                 const recovered = await recoverInterruptedJob(recoveryController.signal)
                 if (!recovered) {
                     if (!recoveryController.signal.aborted) {
+                        setIsAnalyzing(false)
                         setAnalysisRunState('failed', errorMessage)
                         pushAssistant(`请求中断：${errorMessage}\n\n后端任务可能仍在执行，请稍后到历史报告中查看结果。`)
                     }

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -2,7 +2,11 @@ import { useEffect, useRef, useCallback } from 'react'
 import { useAnalysisStore } from '@/stores/analysisStore'
 import type { AnalysisReport, RiskItem, KeyMetric } from '@/types'
 import { getBaseUrl } from '@/services/api'
-import { classifyRecoveredJobStatus, getJobLifecycleUpdate } from '@/utils/jobLifecycle'
+import {
+    classifyRecoveredJobStatus,
+    DEFAULT_OVERTIME_NOTICE,
+    getJobLifecycleUpdate,
+} from '@/utils/jobLifecycle'
 
 export function useSSE(jobId: string | null) {
     const eventSourceRef = useRef<EventSource | null>(null)
@@ -83,7 +87,7 @@ export function useSSE(jobId: string | null) {
                         id: Date.now().toString(),
                         timestamp: new Date().toISOString(),
                         type: 'system',
-                        content: 'Analysis is taking longer than expected and is still running'
+                        content: lifecycleUpdate?.overtimeNotice || DEFAULT_OVERTIME_NOTICE
                     })
                     break
 
@@ -116,7 +120,7 @@ export function useSSE(jobId: string | null) {
                             id: Date.now().toString(),
                             timestamp: new Date().toISOString(),
                             type: 'system',
-                            content: 'Legacy timeout received; analysis may still be running'
+                            content: DEFAULT_OVERTIME_NOTICE
                         })
                         break
                     }

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react'
 import { useAnalysisStore } from '@/stores/analysisStore'
 import type { AnalysisReport, RiskItem, KeyMetric } from '@/types'
 import { getBaseUrl } from '@/services/api'
+import { classifyRecoveredJobStatus, getJobLifecycleUpdate } from '@/utils/jobLifecycle'
 
 export function useSSE(jobId: string | null) {
     const eventSourceRef = useRef<EventSource | null>(null)
@@ -23,6 +24,8 @@ export function useSSE(jobId: string | null) {
         addChatMessage,
         appendToChatMessage,
         setMessageContent,
+        setAnalysisRunState,
+        setAnalysisOvertimeNotice,
     } = useAnalysisStore()
 
     const connect = useCallback(() => {
@@ -43,6 +46,13 @@ export function useSSE(jobId: string | null) {
         }
 
         const handleEvent = (eventType: string, data: Record<string, unknown>) => {
+            const lifecycleUpdate = getJobLifecycleUpdate(eventType, data)
+            if (lifecycleUpdate) {
+                setIsAnalyzing(lifecycleUpdate.isAnalyzing)
+                setAnalysisRunState(lifecycleUpdate.runState, eventType === 'job.failed' ? String(data.error || '未知错误') : null)
+                setAnalysisOvertimeNotice(lifecycleUpdate.overtimeNotice)
+            }
+
             switch (eventType) {
                 case 'job.created':
                     addLog({
@@ -54,7 +64,6 @@ export function useSSE(jobId: string | null) {
                     break
 
                 case 'job.running':
-                    setIsAnalyzing(true)
                     addChatMessage({
                         id: `job-running-${Date.now()}`,
                         role: 'system',
@@ -69,8 +78,16 @@ export function useSSE(jobId: string | null) {
                     })
                     break
 
+                case 'job.overtime':
+                    addLog({
+                        id: Date.now().toString(),
+                        timestamp: new Date().toISOString(),
+                        type: 'system',
+                        content: 'Analysis is taking longer than expected and is still running'
+                    })
+                    break
+
                 case 'job.completed':
-                    setIsAnalyzing(false)
                     setReport((data.result || null) as AnalysisReport | null)
                     setStructuredData({
                         riskItems: (data.risk_items as RiskItem[] | undefined) ?? [],
@@ -94,7 +111,15 @@ export function useSSE(jobId: string | null) {
                     break
 
                 case 'job.failed':
-                    setIsAnalyzing(false)
+                    if (classifyRecoveredJobStatus('failed', typeof data.error === 'string' ? data.error : null) === 'running') {
+                        addLog({
+                            id: Date.now().toString(),
+                            timestamp: new Date().toISOString(),
+                            type: 'system',
+                            content: 'Legacy timeout received; analysis may still be running'
+                        })
+                        break
+                    }
                     addChatMessage({
                         id: `job-failed-${Date.now()}`,
                         role: 'system',
@@ -181,6 +206,7 @@ export function useSSE(jobId: string | null) {
             'job.ready',
             'job.created',
             'job.running',
+            'job.overtime',
             'job.completed',
             'job.failed',
             'agent.status',

--- a/frontend/src/stores/analysisStore.ts
+++ b/frontend/src/stores/analysisStore.ts
@@ -79,6 +79,7 @@ interface AnalysisState {
     isConnected: boolean
     analysisRunState: 'idle' | 'running' | 'completed' | 'failed'
     analysisRunError: string | null
+    analysisOvertimeNotice: string | null
 
     // Current analysis horizon (for badge display)
     currentHorizon: string | null
@@ -107,6 +108,7 @@ interface AnalysisState {
     setIsAnalyzing: (isAnalyzing: boolean) => void
     setIsConnected: (isConnected: boolean) => void
     setAnalysisRunState: (state: 'idle' | 'running' | 'completed' | 'failed', error?: string | null) => void
+    setAnalysisOvertimeNotice: (notice: string | null) => void
     setCurrentHorizon: (horizon: string | null) => void
     addChatMessage: (message: ChatMessage) => void
     appendToChatMessage: (id: string, chunk: string) => void
@@ -190,6 +192,7 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
     isConnected: false,
     analysisRunState: 'idle',
     analysisRunError: null,
+    analysisOvertimeNotice: null,
     currentHorizon: null,
 
     setCurrentJobId: (jobId) => set({ currentJobId: jobId }),
@@ -404,6 +407,7 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
         isConnected: false,
         analysisRunState: 'idle',
         analysisRunError: null,
+        analysisOvertimeNotice: null,
         currentHorizon: null,
     }),
 
@@ -431,7 +435,10 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
     setAnalysisRunState: (analysisRunState, error = null) => set({
         analysisRunState,
         analysisRunError: analysisRunState === 'failed' ? error : null,
+        ...(analysisRunState === 'running' ? {} : { analysisOvertimeNotice: null }),
     }),
+
+    setAnalysisOvertimeNotice: (analysisOvertimeNotice) => set({ analysisOvertimeNotice }),
 
     setCurrentHorizon: (horizon) => set({ currentHorizon: horizon }),
 
@@ -456,6 +463,7 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
         isConnected: false,
         analysisRunState: 'idle',
         analysisRunError: null,
+        analysisOvertimeNotice: null,
         currentHorizon: null,
     }))
 }), {
@@ -491,6 +499,7 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
             isConnected: false,
             analysisRunState: 'idle',
             analysisRunError: null,
+            analysisOvertimeNotice: null,
             chatMessages: persisted.chatMessages?.length ? persisted.chatMessages : currentState.chatMessages,
         }
     },

--- a/frontend/src/stores/analysisStore.ts
+++ b/frontend/src/stores/analysisStore.ts
@@ -479,11 +479,11 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
         jobConfidence: state.jobConfidence,
         jobTargetPrice: state.jobTargetPrice,
         jobStopLoss: state.jobStopLoss,
-        // Filter out transient status indicator messages (e.g. __typing__, __parsing__)
-        // so they don't persist across page refreshes
-        chatMessages: state.chatMessages.filter(m =>
-            !m.content.startsWith('__') &&
-            !(m.role === 'assistant' && m.agent && !m.complete)
+        // Drop transient indicators and pure agent placeholders.  Preserve any
+        // partial agent content, but mark it complete so hydration cannot show
+        // a stale "still writing" state.
+        chatMessages: reconcilePersistedChatMessages(
+            state.chatMessages.filter(m => !m.content.startsWith('__')),
         ),
     }),
     merge: (persistedState, currentState) => {

--- a/frontend/src/stores/analysisStore.ts
+++ b/frontend/src/stores/analysisStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
+import { reconcilePersistedChatMessages } from '@/utils/chatRecovery'
 import type {
     Agent,
     JobStatus,
@@ -27,7 +28,7 @@ export interface ChatMessage {
     timestamp: string
     agent?: string      // The name of the agent who sent the message
     section?: string    // only for role='report'
-    complete?: boolean  // only for role='report'
+    complete?: boolean  // completed report or agent message
 }
 
 const createInitialChatMessages = (): ChatMessage[] => [
@@ -480,10 +481,14 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
         jobStopLoss: state.jobStopLoss,
         // Filter out transient status indicator messages (e.g. __typing__, __parsing__)
         // so they don't persist across page refreshes
-        chatMessages: state.chatMessages.filter(m => !m.content.startsWith('__')),
+        chatMessages: state.chatMessages.filter(m =>
+            !m.content.startsWith('__') &&
+            !(m.role === 'assistant' && m.agent && !m.complete)
+        ),
     }),
     merge: (persistedState, currentState) => {
         const persisted = (persistedState ?? {}) as Partial<AnalysisState>
+        const restoredChatMessages = reconcilePersistedChatMessages(persisted.chatMessages ?? [])
         return {
             ...currentState,
             ...persisted,
@@ -500,7 +505,7 @@ export const useAnalysisStore = create<AnalysisState>()(persist((set) => ({
             analysisRunState: 'idle',
             analysisRunError: null,
             analysisOvertimeNotice: null,
-            chatMessages: persisted.chatMessages?.length ? persisted.chatMessages : currentState.chatMessages,
+            chatMessages: restoredChatMessages.length ? restoredChatMessages : currentState.chatMessages,
         }
     },
 }))

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -113,6 +113,8 @@ export interface JobStatus {
     symbol: string
     trade_date: string
     error?: string
+    overtime?: boolean
+    overtime_at?: string | null
     waiting_ahead_count?: number | null
     scheduled_running_count?: number | null
     scheduled_concurrency_limit?: number | null
@@ -122,6 +124,7 @@ export interface JobStatus {
 export type SSEEventType =
     | 'job.created'
     | 'job.running'
+    | 'job.overtime'
     | 'job.completed'
     | 'job.failed'
     | 'agent.status'

--- a/frontend/src/utils/chatRecovery.test.ts
+++ b/frontend/src/utils/chatRecovery.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { reconcilePersistedChatMessages } from '@/utils/chatRecovery'
+
+describe('reconcilePersistedChatMessages', () => {
+    it('removes an orphaned agent placeholder after page hydration', () => {
+        expect(reconcilePersistedChatMessages([
+            {
+                id: 'aggressive-placeholder',
+                role: 'assistant',
+                agent: 'Aggressive Analyst',
+                content: '**Aggressive Analyst** (短线) 正在思考并撰写报告中...',
+                timestamp: '2026-07-13T06:04:00Z',
+            },
+        ])).toEqual([])
+    })
+
+    it('keeps partial agent content but marks it complete so it cannot show as writing', () => {
+        expect(reconcilePersistedChatMessages([
+            {
+                id: 'aggressive-partial',
+                role: 'assistant',
+                agent: 'Aggressive Analyst',
+                content: '### Aggressive Analyst\n\n已经生成的部分分析内容',
+                timestamp: '2026-07-13T06:04:00Z',
+            },
+        ])).toEqual([
+            {
+                id: 'aggressive-partial',
+                role: 'assistant',
+                agent: 'Aggressive Analyst',
+                content: '### Aggressive Analyst\n\n已经生成的部分分析内容',
+                timestamp: '2026-07-13T06:04:00Z',
+                complete: true,
+            },
+        ])
+    })
+
+    it('leaves user, report and completed agent messages unchanged', () => {
+        const messages = [
+            { id: 'user', role: 'user', content: '分析一下', timestamp: 'now' },
+            { id: 'report', role: 'report', content: '完整报告', timestamp: 'now', complete: true },
+            {
+                id: 'agent',
+                role: 'assistant',
+                agent: 'Trader',
+                content: '交易计划',
+                timestamp: 'now',
+                complete: true,
+            },
+        ]
+        expect(reconcilePersistedChatMessages(messages)).toEqual(messages)
+    })
+})

--- a/frontend/src/utils/chatRecovery.ts
+++ b/frontend/src/utils/chatRecovery.ts
@@ -1,0 +1,25 @@
+export interface RecoverableChatMessage {
+    role: string
+    content: string
+    agent?: string
+    complete?: boolean
+}
+
+const AGENT_PLACEHOLDER_PATTERN = /正在思考并撰写报告中/
+
+export function reconcilePersistedChatMessages<T extends RecoverableChatMessage>(messages: T[]): T[] {
+    return messages.reduce<T[]>((restored, message) => {
+        const orphanedAgentMessage = message.role === 'assistant' && Boolean(message.agent) && !message.complete
+        if (!orphanedAgentMessage) {
+            restored.push(message)
+            return restored
+        }
+
+        if (AGENT_PLACEHOLDER_PATTERN.test(message.content)) {
+            return restored
+        }
+
+        restored.push({ ...message, complete: true })
+        return restored
+    }, [])
+}

--- a/frontend/src/utils/jobLifecycle.test.ts
+++ b/frontend/src/utils/jobLifecycle.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyRecoveredJobStatus, getJobLifecycleUpdate } from '@/utils/jobLifecycle'
+
+describe('getJobLifecycleUpdate', () => {
+    it('treats overtime as a non-terminal running state', () => {
+        expect(getJobLifecycleUpdate('job.overtime')).toEqual({
+            isAnalyzing: true,
+            runState: 'running',
+            overtimeNotice: '分析耗时较长，后台仍在继续，请勿重复提交。',
+        })
+    })
+
+    it('uses the backend overtime copy when provided', () => {
+        expect(getJobLifecycleUpdate('job.overtime', { msg: '仍在生成最终报告' })?.overtimeNotice)
+            .toBe('仍在生成最终报告')
+    })
+
+    it('clears an overtime notice only when a terminal event arrives', () => {
+        expect(getJobLifecycleUpdate('job.completed')).toMatchObject({
+            isAnalyzing: false,
+            runState: 'completed',
+            overtimeNotice: null,
+        })
+        expect(getJobLifecycleUpdate('job.failed')).toMatchObject({
+            isAnalyzing: false,
+            runState: 'failed',
+            overtimeNotice: null,
+        })
+    })
+
+    it('keeps compatibility with unrelated events from older backends', () => {
+        expect(getJobLifecycleUpdate('agent.status', { status: 'in_progress' })).toBeNull()
+    })
+})
+
+describe('classifyRecoveredJobStatus', () => {
+    it('keeps polling an old server after its false 1800-second failure', () => {
+        expect(classifyRecoveredJobStatus('failed', '任务超时（超过 1800 秒），已自动终止')).toBe('running')
+        expect(classifyRecoveredJobStatus('failed', 'job timeout exceeded 1800 seconds')).toBe('running')
+        expect(getJobLifecycleUpdate('job.failed', {
+            error: '任务超时（超过 1800 秒），已自动终止',
+        })).toMatchObject({
+            isAnalyzing: true,
+            runState: 'running',
+        })
+    })
+
+    it('still treats real backend failures as terminal', () => {
+        expect(classifyRecoveredJobStatus('failed', 'GLM API authentication failed')).toBe('failed')
+        expect(classifyRecoveredJobStatus('completed')).toBe('completed')
+        expect(classifyRecoveredJobStatus('running')).toBe('running')
+    })
+})

--- a/frontend/src/utils/jobLifecycle.test.ts
+++ b/frontend/src/utils/jobLifecycle.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from 'vitest'
 
-import { classifyRecoveredJobStatus, getJobLifecycleUpdate } from '@/utils/jobLifecycle'
+import {
+    classifyRecoveredJobStatus,
+    getJobLifecycleUpdate,
+    hasRecoveryPollingReachedLimit,
+    RECOVERY_POLL_MAX_ATTEMPTS,
+} from '@/utils/jobLifecycle'
 
 describe('getJobLifecycleUpdate', () => {
     it('treats overtime as a non-terminal running state', () => {
         expect(getJobLifecycleUpdate('job.overtime')).toEqual({
             isAnalyzing: true,
             runState: 'running',
-            overtimeNotice: '分析耗时较长，后台仍在继续，请勿重复提交。',
+            overtimeNotice: '分析耗时较长，后台仍在继续，正在等待最终结果，请勿重复提交。',
         })
     })
 
@@ -31,6 +36,13 @@ describe('getJobLifecycleUpdate', () => {
 
     it('keeps compatibility with unrelated events from older backends', () => {
         expect(getJobLifecycleUpdate('agent.status', { status: 'in_progress' })).toBeNull()
+    })
+})
+
+describe('hasRecoveryPollingReachedLimit', () => {
+    it('stops recovery polling after two hours of three-second retries', () => {
+        expect(hasRecoveryPollingReachedLimit(RECOVERY_POLL_MAX_ATTEMPTS - 1)).toBe(false)
+        expect(hasRecoveryPollingReachedLimit(RECOVERY_POLL_MAX_ATTEMPTS)).toBe(true)
     })
 })
 

--- a/frontend/src/utils/jobLifecycle.ts
+++ b/frontend/src/utils/jobLifecycle.ts
@@ -8,7 +8,16 @@ export interface JobLifecycleUpdate {
 
 export type RecoveredJobDisposition = 'running' | 'completed' | 'failed'
 
-const DEFAULT_OVERTIME_NOTICE = '分析耗时较长，后台仍在继续，请勿重复提交。'
+export const DEFAULT_OVERTIME_NOTICE = '分析耗时较长，后台仍在继续，正在等待最终结果，请勿重复提交。'
+export const RECOVERY_POLL_MAX_ATTEMPTS = 2 * 60 * 60 / 3
+export const RECOVERY_POLL_TIMEOUT_MESSAGE = '已停止等待任务状态。后端任务可能仍在处理，请稍后到历史报告查看最终结果。'
+
+export function hasRecoveryPollingReachedLimit(
+    attempts: number,
+    maxAttempts: number = RECOVERY_POLL_MAX_ATTEMPTS,
+): boolean {
+    return attempts >= maxAttempts
+}
 
 export function getJobLifecycleUpdate(
     eventName: string,

--- a/frontend/src/utils/jobLifecycle.ts
+++ b/frontend/src/utils/jobLifecycle.ts
@@ -1,0 +1,54 @@
+export type AnalysisRunState = 'idle' | 'running' | 'completed' | 'failed'
+
+export interface JobLifecycleUpdate {
+    isAnalyzing: boolean
+    runState: AnalysisRunState
+    overtimeNotice: string | null
+}
+
+export type RecoveredJobDisposition = 'running' | 'completed' | 'failed'
+
+const DEFAULT_OVERTIME_NOTICE = '分析耗时较长，后台仍在继续，请勿重复提交。'
+
+export function getJobLifecycleUpdate(
+    eventName: string,
+    data: Record<string, unknown> = {},
+): JobLifecycleUpdate | null {
+    switch (eventName) {
+        case 'job.running':
+            return { isAnalyzing: true, runState: 'running', overtimeNotice: null }
+        case 'job.overtime': {
+            const suppliedMessage = data.message ?? data.msg
+            return {
+                isAnalyzing: true,
+                runState: 'running',
+                overtimeNotice: typeof suppliedMessage === 'string' && suppliedMessage.trim()
+                    ? suppliedMessage
+                    : DEFAULT_OVERTIME_NOTICE,
+            }
+        }
+        case 'job.completed':
+            return { isAnalyzing: false, runState: 'completed', overtimeNotice: null }
+        case 'job.failed':
+            if (classifyRecoveredJobStatus('failed', typeof data.error === 'string' ? data.error : null) === 'running') {
+                return {
+                    isAnalyzing: true,
+                    runState: 'running',
+                    overtimeNotice: DEFAULT_OVERTIME_NOTICE,
+                }
+            }
+            return { isAnalyzing: false, runState: 'failed', overtimeNotice: null }
+        default:
+            return null
+    }
+}
+
+export function classifyRecoveredJobStatus(status: string, error?: string | null): RecoveredJobDisposition {
+    if (status === 'completed') return 'completed'
+    if (status !== 'failed') return 'running'
+
+    // Older servers marked the outer 1800-second watchdog as failed even though
+    // the inner analysis continued and could still persist a completed report.
+    const legacySoftTimeout = /(?:任务超时[^\n]*(?:1800|秒)|(?:timeout|timed out)[^\n]*1800)/i.test(error || '')
+    return legacySoftTimeout ? 'running' : 'failed'
+}

--- a/tests/test_job_lifecycle.py
+++ b/tests/test_job_lifecycle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from unittest.mock import patch
 
 from api.job_store import InMemoryJobStore
@@ -39,6 +40,7 @@ def test_soft_timeout_emits_overtime_then_allows_completion():
         with (
             patch.object(main, "_job_store_instance", store),
             patch.object(main, "_JOB_TIMEOUT", 0.01),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 1),
             patch.object(main, "_run_job_inner", side_effect=fake_inner),
             patch.object(main, "_emit_job_event", side_effect=capture_event),
         ):
@@ -57,7 +59,8 @@ def test_soft_timeout_emits_overtime_then_allows_completion():
     assert job["status"] == "completed"
     assert job["error"] is None
     assert job["overtime"] is False
-    assert events[0][1]["elapsed_seconds"] == 0.01
+    assert events[0][1]["elapsed_seconds"] >= 0.01
+    assert events[0][1]["soft_timeout_seconds"] == 0.01
 
 
 def test_job_finishing_before_deadline_does_not_emit_overtime():
@@ -72,6 +75,7 @@ def test_job_finishing_before_deadline_does_not_emit_overtime():
         with (
             patch.object(main, "_job_store_instance", store),
             patch.object(main, "_JOB_TIMEOUT", 1),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 2),
             patch.object(main, "_run_job_inner", side_effect=fake_inner),
             patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
         ):
@@ -95,9 +99,12 @@ def test_completed_task_is_not_overwritten_by_stale_wait_snapshot():
         return set(), {task}
 
     async def scenario() -> None:
+        # main.asyncio is the process-wide asyncio module.  This patch is
+        # intentionally scoped to the context so it cannot leak to other tests.
         with (
             patch.object(main, "_job_store_instance", store),
             patch.object(main, "_JOB_TIMEOUT", 1),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 2),
             patch.object(main, "_run_job_inner", side_effect=fake_inner),
             patch.object(main.asyncio, "wait", side_effect=stale_wait_snapshot),
             patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
@@ -122,6 +129,7 @@ def test_zero_timeout_disables_warning_but_still_waits_for_completion():
         with (
             patch.object(main, "_job_store_instance", store),
             patch.object(main, "_JOB_TIMEOUT", 0),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 1),
             patch.object(main, "_run_job_inner", side_effect=fake_inner),
             patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
         ):
@@ -147,6 +155,7 @@ def test_unexpected_inner_exception_marks_job_failed():
         with (
             patch.object(main, "_job_store_instance", store),
             patch.object(main, "_JOB_TIMEOUT", 1),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 2),
             patch.object(main, "_run_job_inner", side_effect=failing_inner),
             patch.object(main, "_emit_job_event", side_effect=capture_event),
             patch.object(main, "get_db_ctx", side_effect=RuntimeError("db disabled")),
@@ -174,6 +183,7 @@ def test_overtime_job_that_later_raises_finishes_as_failed():
         with (
             patch.object(main, "_job_store_instance", store),
             patch.object(main, "_JOB_TIMEOUT", 0.01),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 1),
             patch.object(main, "_run_job_inner", side_effect=failing_inner),
             patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
             patch.object(main, "get_db_ctx", side_effect=RuntimeError("db disabled")),
@@ -187,6 +197,43 @@ def test_overtime_job_that_later_raises_finishes_as_failed():
     assert job["error"] == "RuntimeError: late failure"
     assert job["overtime"] is False
     assert job["overtime_at"] is None
+
+
+def test_hard_timeout_releases_wrapper_and_ignores_late_thread_result():
+    store = InMemoryJobStore()
+    events: list[tuple[str, dict]] = []
+    release_thread = threading.Event()
+
+    async def blocked_inner(job_id, *_args, **_kwargs):
+        await asyncio.to_thread(release_thread.wait)
+        main._set_job(job_id, status="completed", error=None, overtime=False)
+        main._emit_job_event(job_id, "job.completed", {"job_id": job_id})
+
+    async def scenario() -> None:
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 0.01),
+            patch.object(main, "_JOB_HARD_TIMEOUT", 0.03),
+            patch.object(main, "_run_job_inner", side_effect=blocked_inner),
+            patch.object(main, "_emit_job_event", side_effect=lambda _j, event, data: events.append((event, data))),
+            patch.object(main, "get_db_ctx", side_effect=RuntimeError("db disabled")),
+        ):
+            await main._run_job("job-hard-timeout", _request())
+            assert store.get_job("job-hard-timeout")["status"] == "failed"
+            release_thread.set()
+            await asyncio.sleep(0.02)
+
+    try:
+        asyncio.run(scenario())
+    finally:
+        release_thread.set()
+
+    job = store.get_job("job-hard-timeout")
+    assert [event for event, _ in events] == ["job.overtime", "job.failed"]
+    assert job["status"] == "failed"
+    assert "硬性运行上限" in job["error"]
+    assert job["overtime"] is False
+    assert events[-1][1]["hard_timeout_seconds"] == 0.03
 
 
 def test_report_save_failure_is_raised_to_the_job_failure_boundary():

--- a/tests/test_job_lifecycle.py
+++ b/tests/test_job_lifecycle.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+from api.job_store import InMemoryJobStore
+from api import main
+
+
+def _request() -> main.AnalyzeRequest:
+    return main.AnalyzeRequest(symbol="600519.SH", trade_date="2026-07-10")
+
+
+def test_soft_timeout_emits_overtime_then_allows_completion():
+    store = InMemoryJobStore()
+    events: list[tuple[str, dict]] = []
+    store.set_job("job-1", status="running", error="stale error")
+
+    def capture_event(job_id: str, event: str, data: dict) -> None:
+        events.append((event, data))
+        store.emit_event(job_id, event, data)
+
+    async def scenario() -> None:
+        release_inner = asyncio.Event()
+
+        async def fake_inner(job_id, *_args, **_kwargs):
+            await release_inner.wait()
+            main._set_job(
+                job_id,
+                status="completed",
+                result={"decision": "BUY"},
+                error=None,
+                overtime=False,
+                overtime_at=None,
+                finished_at=main._utcnow_iso(),
+            )
+            main._emit_job_event(job_id, "job.completed", {"job_id": job_id})
+
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 0.01),
+            patch.object(main, "_run_job_inner", side_effect=fake_inner),
+            patch.object(main, "_emit_job_event", side_effect=capture_event),
+        ):
+            wrapper = asyncio.create_task(main._run_job("job-1", _request()))
+            await asyncio.sleep(0.02)
+            assert not wrapper.done(), "soft deadline must not release the wrapper/scheduler slot"
+            assert [event for event, _ in events] == ["job.overtime"]
+            assert store.get_job("job-1")["status"] == "running"
+            release_inner.set()
+            await wrapper
+
+    asyncio.run(scenario())
+
+    job = store.get_job("job-1")
+    assert [event for event, _ in events] == ["job.overtime", "job.completed"]
+    assert job["status"] == "completed"
+    assert job["error"] is None
+    assert job["overtime"] is False
+    assert events[0][1]["elapsed_seconds"] == 0.01
+
+
+def test_job_finishing_before_deadline_does_not_emit_overtime():
+    store = InMemoryJobStore()
+    events: list[str] = []
+
+    async def fake_inner(job_id, *_args, **_kwargs):
+        main._set_job(job_id, status="completed", error=None, overtime=False)
+        main._emit_job_event(job_id, "job.completed", {"job_id": job_id})
+
+    async def scenario() -> None:
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 1),
+            patch.object(main, "_run_job_inner", side_effect=fake_inner),
+            patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
+        ):
+            await main._run_job("job-fast", _request())
+
+    asyncio.run(scenario())
+    assert events == ["job.completed"]
+
+
+def test_zero_timeout_disables_warning_but_still_waits_for_completion():
+    store = InMemoryJobStore()
+    events: list[str] = []
+
+    async def fake_inner(job_id, *_args, **_kwargs):
+        await asyncio.sleep(0.01)
+        main._set_job(job_id, status="completed", error=None, overtime=False)
+        main._emit_job_event(job_id, "job.completed", {"job_id": job_id})
+
+    async def scenario() -> None:
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 0),
+            patch.object(main, "_run_job_inner", side_effect=fake_inner),
+            patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
+        ):
+            await main._run_job("job-no-warning", _request())
+
+    asyncio.run(scenario())
+    assert store.get_job("job-no-warning")["status"] == "completed"
+    assert events == ["job.completed"]
+
+
+def test_unexpected_inner_exception_marks_job_failed():
+    store = InMemoryJobStore()
+    events: list[tuple[str, dict]] = []
+    store.set_job("job-2", status="running", error=None)
+
+    async def failing_inner(*_args, **_kwargs):
+        raise RuntimeError("model unavailable")
+
+    def capture_event(_job_id: str, event: str, data: dict) -> None:
+        events.append((event, data))
+
+    async def scenario() -> None:
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 1),
+            patch.object(main, "_run_job_inner", side_effect=failing_inner),
+            patch.object(main, "_emit_job_event", side_effect=capture_event),
+            patch.object(main, "get_db_ctx", side_effect=RuntimeError("db disabled")),
+        ):
+            await main._run_job("job-2", _request())
+
+    asyncio.run(scenario())
+
+    job = store.get_job("job-2")
+    assert [event for event, _ in events] == ["job.failed"]
+    assert job["status"] == "failed"
+    assert job["error"] == "RuntimeError: model unavailable"
+    assert job["overtime"] is False
+
+
+def test_overtime_job_that_later_raises_finishes_as_failed():
+    store = InMemoryJobStore()
+    events: list[str] = []
+
+    async def failing_inner(*_args, **_kwargs):
+        await asyncio.sleep(0.02)
+        raise RuntimeError("late failure")
+
+    async def scenario() -> None:
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 0.01),
+            patch.object(main, "_run_job_inner", side_effect=failing_inner),
+            patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
+            patch.object(main, "get_db_ctx", side_effect=RuntimeError("db disabled")),
+        ):
+            await main._run_job("job-late-failure", _request())
+
+    asyncio.run(scenario())
+    job = store.get_job("job-late-failure")
+    assert events == ["job.overtime", "job.failed"]
+    assert job["status"] == "failed"
+    assert job["error"] == "RuntimeError: late failure"
+    assert job["overtime"] is False
+    assert job["overtime_at"] is None
+
+
+def test_report_save_failure_is_raised_to_the_job_failure_boundary():
+    def failing_save():
+        raise OSError("disk full")
+
+    async def scenario() -> None:
+        try:
+            await main._save_report_or_raise("job-db", failing_save, stage="save")
+        except RuntimeError as exc:
+            assert "Failed to save report for job job-db" in str(exc)
+            assert isinstance(exc.__cause__, OSError)
+        else:
+            raise AssertionError("report persistence errors must not be swallowed")
+
+    asyncio.run(scenario())

--- a/tests/test_job_lifecycle.py
+++ b/tests/test_job_lifecycle.py
@@ -81,6 +81,34 @@ def test_job_finishing_before_deadline_does_not_emit_overtime():
     assert events == ["job.completed"]
 
 
+def test_completed_task_is_not_overwritten_by_stale_wait_snapshot():
+    store = InMemoryJobStore()
+    events: list[str] = []
+
+    async def fake_inner(job_id, *_args, **_kwargs):
+        main._set_job(job_id, status="completed", error=None, overtime=False)
+        main._emit_job_event(job_id, "job.completed", {"job_id": job_id})
+
+    async def stale_wait_snapshot(tasks, **_kwargs):
+        task = next(iter(tasks))
+        await task
+        return set(), {task}
+
+    async def scenario() -> None:
+        with (
+            patch.object(main, "_job_store_instance", store),
+            patch.object(main, "_JOB_TIMEOUT", 1),
+            patch.object(main, "_run_job_inner", side_effect=fake_inner),
+            patch.object(main.asyncio, "wait", side_effect=stale_wait_snapshot),
+            patch.object(main, "_emit_job_event", side_effect=lambda _j, event, _d: events.append(event)),
+        ):
+            await main._run_job("job-stale-wait", _request())
+
+    asyncio.run(scenario())
+    assert events == ["job.completed"]
+    assert store.get_job("job-stale-wait")["status"] == "completed"
+
+
 def test_zero_timeout_disables_warning_but_still_waits_for_completion():
     store = InMemoryJobStore()
     events: list[str] = []

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -69,6 +69,36 @@ def test_emit_and_subscribe():
     asyncio.run(scenario())
 
 
+def test_overtime_event_is_non_terminal_and_completion_still_arrives():
+    async def scenario():
+        store = _make_store()
+        store.set_job("j1", status="running", overtime=False)
+
+        collected = []
+
+        async def emit_lifecycle():
+            await asyncio.sleep(0)
+            store.set_job("j1", status="running", overtime=True)
+            store.emit_event("j1", "job.overtime", {"elapsed_seconds": 1800})
+            await asyncio.sleep(0)
+            store.set_job("j1", status="completed", overtime=False)
+            store.emit_event("j1", "job.completed", {"result": "ok"})
+
+        emitter = asyncio.create_task(emit_lifecycle())
+        async for event in store.subscribe("j1", poll_interval=0.05):
+            collected.append(event)
+        await emitter
+
+        assert [event["event"] for event in collected] == [
+            "job.overtime",
+            "job.completed",
+        ]
+        assert collected[0]["data"] == {"elapsed_seconds": 1800}
+        assert collected[1]["data"] == {"result": "ok"}
+
+    asyncio.run(scenario())
+
+
 def test_subscribe_timeout_ping():
     async def scenario():
         store = _make_store()

--- a/tests/test_job_store_redis.py
+++ b/tests/test_job_store_redis.py
@@ -85,6 +85,13 @@ def test_none_roundtrip(store: RedisJobStore):
     assert job["result"] is None
 
 
+def test_boolean_roundtrip(store: RedisJobStore):
+    store.set_job("j1", overtime=False)
+    assert store.get_job("j1")["overtime"] is False
+    store.set_job("j1", overtime=True)
+    assert store.get_job("j1")["overtime"] is True
+
+
 def test_complex_value_roundtrip(store: RedisJobStore):
     """Dict and list values should round-trip via JSON serialization."""
     store.set_job("j1", report={"score": 8, "tags": ["buy", "hold"]}, items=[1, 2, 3])
@@ -147,6 +154,36 @@ def test_pubsub(store: RedisJobStore):
         assert collected[2]["data"] == {"result": "ok"}
         for ev in collected:
             assert "timestamp" in ev
+
+    asyncio.run(scenario())
+
+
+def test_overtime_event_is_non_terminal_and_completion_still_arrives(store: RedisJobStore):
+    async def scenario():
+        store.set_job("j1", status="running", overtime=False)
+        collected = []
+
+        async def _emit_later():
+            # Redis Pub/Sub has no replay, so allow the listener thread to
+            # subscribe before publishing the lifecycle events.
+            await asyncio.sleep(0.3)
+            store.set_job("j1", status="running", overtime=True)
+            store.emit_event("j1", "job.overtime", {"elapsed_seconds": 1800})
+            await asyncio.sleep(0.05)
+            store.set_job("j1", status="completed", overtime=False)
+            store.emit_event("j1", "job.completed", {"result": "ok"})
+
+        emitter = asyncio.create_task(_emit_later())
+        async for event in store.subscribe("j1", poll_interval=1.0):
+            collected.append(event)
+        await emitter
+
+        assert [event["event"] for event in collected] == [
+            "job.overtime",
+            "job.completed",
+        ]
+        assert collected[0]["data"] == {"elapsed_seconds": 1800}
+        assert collected[1]["data"] == {"result": "ok"}
 
     asyncio.run(scenario())
 

--- a/tests/test_report_recovery.py
+++ b/tests/test_report_recovery.py
@@ -52,7 +52,7 @@ def test_recover_stale_active_reports_marks_empty_running_report_failed():
         result = report_service.recover_stale_active_reports(db)
 
         refreshed = db.query(ReportDB).filter(ReportDB.id == report.id).first()
-        assert result == {"total": 1, "completed": 0, "failed": 1}
+        assert result == {"total": 1, "failed": 1}
         assert refreshed is not None
         assert refreshed.status == "failed"
         assert refreshed.error == report_service.STALE_REPORT_ERROR_MESSAGE
@@ -73,7 +73,7 @@ def test_recover_stale_active_reports_marks_partial_running_report_failed():
         result = report_service.recover_stale_active_reports(db)
 
         refreshed = db.query(ReportDB).filter(ReportDB.id == report.id).first()
-        assert result == {"total": 1, "completed": 0, "failed": 1}
+        assert result == {"total": 1, "failed": 1}
         assert refreshed is not None
         assert refreshed.status == "failed"
         assert refreshed.error == report_service.STALE_REPORT_ERROR_MESSAGE

--- a/tests/test_report_recovery.py
+++ b/tests/test_report_recovery.py
@@ -22,6 +22,7 @@ def _add_report(
     decision=None,
     final_trade_decision=None,
     result_data=None,
+    error=None,
 ):
     now = datetime.now(timezone.utc)
     report = ReportDB(
@@ -33,6 +34,7 @@ def _add_report(
         decision=decision,
         final_trade_decision=final_trade_decision,
         result_data=result_data,
+        error=error,
         created_at=now,
         updated_at=now,
     )
@@ -88,5 +90,30 @@ def test_finalize_orphan_report_marks_pending_report_failed():
 
         assert refreshed.status == "failed"
         assert refreshed.error == report_service.STALE_REPORT_ERROR_MESSAGE
+    finally:
+        db.close()
+
+
+def test_create_report_clears_previous_failure_error_on_success():
+    db = _make_session()
+    try:
+        report = _add_report(
+            db,
+            status="failed",
+            error="任务超时（旧策略）",
+        )
+
+        finalized = report_service.create_report(
+            db=db,
+            symbol=report.symbol,
+            trade_date=report.trade_date,
+            decision="BUY",
+            result_data={"final_trade_decision": "结论：买入"},
+            report_id=report.id,
+        )
+
+        assert finalized.status == "completed"
+        assert finalized.error is None
+        assert finalized.decision == "BUY"
     finally:
         db.close()

--- a/tests/test_scheduler_overtime_lifecycle.py
+++ b/tests/test_scheduler_overtime_lifecycle.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from scheduler import main as scheduler_main
+
+
+def test_scheduled_slot_and_success_wait_for_analysis_terminal_outcome():
+    """A long analysis must retain its scheduler slot until `_run_job` returns.
+
+    The production `_run_job` emits the soft overtime notification while it
+    continues awaiting its inner task.  This scheduler-level regression test
+    verifies that downstream success recording and notifications cannot run at
+    that intermediate point, and that a queued analysis cannot acquire the
+    released slot early.
+    """
+
+    async def scenario() -> None:
+        scheduler_main._semaphore = asyncio.Semaphore(1)
+        first_started = asyncio.Event()
+        second_started = asyncio.Event()
+        release_first = asyncio.Event()
+        call_order: list[str] = []
+
+        async def fake_run_job(job_id, *_args, **_kwargs):
+            call_order.append(f"start:{job_id}")
+            if job_id == "job-first":
+                first_started.set()
+                await release_first.wait()
+            else:
+                second_started.set()
+            call_order.append(f"finish:{job_id}")
+
+        mark_success = Mock(side_effect=lambda *_args, **_kwargs: call_order.append("success"))
+        send_notifications = AsyncMock(
+            side_effect=lambda *_args, **_kwargs: call_order.append("notify")
+        )
+
+        task_data = {
+            "id": "schedule-1",
+            "user_id": "user-1",
+            "symbol": "600519.SH",
+            "horizon": "short",
+            # Keep this truthy so the scheduler does not enter the unrelated
+            # imported-portfolio DB lookup path in this lifecycle-only test.
+            "manual_user_context": {"objective": "lifecycle regression"},
+        }
+
+        with (
+            patch.object(
+                scheduler_main,
+                "get_db_ctx",
+                side_effect=lambda: nullcontext(SimpleNamespace()),
+            ),
+            patch.object(
+                scheduler_main,
+                "_build_scheduled_analyze_request",
+                return_value=SimpleNamespace(symbol="600519.SH"),
+            ),
+            patch.object(scheduler_main, "_run_job", side_effect=fake_run_job),
+            patch.object(scheduler_main, "_get_job", return_value={"status": "completed"}),
+            patch.object(scheduler_main.scheduled_service, "mark_run_success", mark_success),
+            patch.object(
+                scheduler_main,
+                "_send_scheduled_report_notifications",
+                send_notifications,
+            ),
+        ):
+            first = asyncio.create_task(
+                scheduler_main._run_scheduled_analysis_once(
+                    task_data,
+                    "2026-07-10",
+                    "job-first",
+                    mark_schedule_run=True,
+                )
+            )
+            await first_started.wait()
+
+            second = asyncio.create_task(
+                scheduler_main._run_scheduled_analysis_once(
+                    task_data,
+                    "2026-07-10",
+                    "job-second",
+                    mark_schedule_run=True,
+                )
+            )
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            assert not first.done()
+            assert not second_started.is_set()
+            mark_success.assert_not_called()
+            send_notifications.assert_not_awaited()
+
+            release_first.set()
+            await asyncio.gather(first, second)
+
+        assert second_started.is_set()
+        assert mark_success.call_count == 2
+        assert send_notifications.await_count == 2
+        assert call_order.index("finish:job-first") < call_order.index("start:job-second")
+        assert call_order.index("finish:job-first") < call_order.index("success")
+        assert call_order.index("success") < call_order.index("notify")
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## 问题

`TA_JOB_TIMEOUT=1800` 原先会被当作任务终态：外层任务直接写入失败并中断前端跟踪，但底层多 Agent 工作流可能仍在执行，最终报告甚至能够正常落库，造成页面状态与真实执行结果不一致。

## 修改

- 将 `TA_JOB_TIMEOUT` 调整为软期限：到期发出 `job.overtime`，任务仍保持 `running`
- 不取消内层分析任务，等待其真实完成或异常后再写入 `completed` / `failed`
- 报告持久化失败不再静默吞掉
- Redis 状态存储正确序列化布尔值
- SSE 中断后持续轮询，直到任务进入真实终态，并展示超时继续运行提示
- 补充任务生命周期、持久化、恢复和超时回归测试
- 对齐现有 stale report 恢复函数的返回字典契约

## 验证

- 后端定向测试：`23 passed, 11 skipped`（Redis 未运行时条件跳过）
- 前端生命周期测试：`6 passed`
- 前端生产构建：`npm run build`

本 PR 不包含 K 线回测模块、回测接口或回测文档改动。
