### PR TITLE
feat(dataflows): 集成 You.com Search 与 Research API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,10 @@ TA_LLM_DEEP=gpt-4o
 # MAIL_FROM=发件人名称
 # MAIL_SSL=1
 
+# --- You.com 联网搜索与深度研究 (You.com Search & Research) ---
+# 用于 AI 分析师的联网搜索和深度研究功能
+# 申请地址: https://ydc-index.io/docs
+# YOUCOM_API_KEY=
+
 # 兼容说明: 系统自动识别 TA_ 前缀变量。
 # 若需修改默认行为，取消上述注释并填值即可。

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -18,6 +18,9 @@ from tradingagents.agents.utils.news_data_tools import (
     get_insider_transactions,
     get_global_news
 )
+from tradingagents.agents.utils.youcom_news_tools import (
+    get_deep_research
+)
 from tradingagents.agents.utils.game_theory_tools import (
     get_board_fund_flow,
     get_individual_fund_flow,

--- a/tradingagents/agents/utils/youcom_news_tools.py
+++ b/tradingagents/agents/utils/youcom_news_tools.py
@@ -1,0 +1,31 @@
+from langchain_core.tools import tool
+from typing import Annotated
+from tradingagents.dataflows.providers.registry import _registry
+
+
+@tool
+def get_deep_research(
+    query: Annotated[str, "Research topic or question — be specific about what to investigate"],
+    research_effort: Annotated[
+        str,
+        "Research depth: lite (quick), standard (balanced), deep (thorough), exhaustive (most comprehensive)"
+    ] = "standard",
+) -> str:
+    """
+    Perform deep research on a topic using You.com Research API, returning a comprehensive
+    markdown report with citations. Use this when you need in-depth analysis of a company,
+    industry trend, market event, or any topic requiring synthesis from multiple sources.
+
+    This tool is particularly useful for fundamental analysis, industry research,
+    and investigating specific events or developments affecting a stock.
+    """
+    provider = _registry.get("youcom")
+    if provider is None:
+        return "You.com provider is not registered. Please ensure YOUCOM_API_KEY is configured."
+
+    try:
+        return provider.get_research(query, research_effort)
+    except NotImplementedError:
+        return "You.com deep research is not available. Please check YOUCOM_API_KEY configuration."
+    except Exception as e:
+        return f"You.com Research failed: {e}"

--- a/tradingagents/dataflows/providers/base.py
+++ b/tradingagents/dataflows/providers/base.py
@@ -63,3 +63,17 @@ class BaseMarketDataProvider(ABC):
         price, open, high, low, previous_close, change, change_pct, volume, amount.
         """
         raise NotImplementedError
+
+    def get_research(self, query: str, research_effort: str = "standard") -> str:
+        """Perform deep research using You.com Research API (or equivalent).
+
+        Args:
+            query: Research topic or question
+            research_effort: lite, standard, deep, or exhaustive
+
+        Returns:
+            Markdown-formatted research report with citations
+        """
+        raise NotImplementedError(
+            f"{self.name} provider does not support deep research"
+        )

--- a/tradingagents/dataflows/providers/registry.py
+++ b/tradingagents/dataflows/providers/registry.py
@@ -7,6 +7,7 @@ from .china_equity_provider import CnStubProvider
 from .cn_akshare_provider import CnAkshareProvider
 from .cn_baostock_provider import CnBaoStockProvider
 from .cn_investoday_provider import CnInvestodayProvider
+from .youcom_provider import YoucomProvider
 
 
 class DataProviderRegistry:
@@ -33,4 +34,5 @@ def build_default_registry() -> DataProviderRegistry:
     registry.register(YFinanceProvider())
     registry.register(AlphaVantageProvider())
     registry.register(CnStubProvider())
+    registry.register(YoucomProvider())
     return registry

--- a/tradingagents/dataflows/providers/youcom_provider.py
+++ b/tradingagents/dataflows/providers/youcom_provider.py
@@ -1,0 +1,76 @@
+from .base import BaseMarketDataProvider
+from .. import youcom_news
+
+
+class YoucomProvider(BaseMarketDataProvider):
+    """You.com data provider using You.com Search and Research APIs."""
+
+    @property
+    def name(self) -> str:
+        return "youcom"
+
+    def get_stock_data(self, symbol: str, start_date: str, end_date: str) -> str:
+        # Not implemented — use You.com Search for news, not stock price data
+        raise NotImplementedError("YoucomProvider does not support stock price data")
+
+    def get_indicators(
+        self, symbol: str, indicator: str, curr_date: str, look_back_days: int
+    ) -> str:
+        raise NotImplementedError("YoucomProvider does not support technical indicators")
+
+    def get_fundamentals(self, ticker: str, curr_date: str = None) -> str:
+        raise NotImplementedError("YoucomProvider does not support fundamental data")
+
+    def get_balance_sheet(
+        self, ticker: str, freq: str = "quarterly", curr_date: str = None
+    ) -> str:
+        raise NotImplementedError("YoucomProvider does not support balance sheet data")
+
+    def get_cashflow(
+        self, ticker: str, freq: str = "quarterly", curr_date: str = None
+    ) -> str:
+        raise NotImplementedError("YoucomProvider does not support cashflow data")
+
+    def get_income_statement(
+        self, ticker: str, freq: str = "quarterly", curr_date: str = None
+    ) -> str:
+        raise NotImplementedError("YoucomProvider does not support income statement data")
+
+    def get_news(self, ticker: str, start_date: str, end_date: str) -> str:
+        query = f"{ticker} stock news {start_date} to {end_date}"
+        return youcom_news.search_news(query, count=10)
+
+    def get_global_news(
+        self, curr_date: str, look_back_days: int = 7, limit: int = 10
+    ) -> str:
+        from datetime import datetime, timedelta
+        try:
+            end_dt = datetime.strptime(curr_date, "%Y-%m-%d")
+        except (ValueError, TypeError):
+            end_dt = datetime.now()
+        start_dt = end_dt - timedelta(days=look_back_days)
+        start_str = start_dt.strftime("%Y-%m-%d")
+
+        query = f"global markets economy Federal Reserve inflation {start_str} to {curr_date}"
+        return youcom_news.search_news(query, count=limit)
+
+    def get_insider_transactions(self, symbol: str, curr_date: str = None) -> str:
+        raise NotImplementedError("YoucomProvider does not support insider transactions")
+
+    def get_realtime_quotes(self, symbols: list[str]) -> str:
+        raise NotImplementedError("YoucomProvider does not support realtime quotes")
+
+    # ── Extended methods not in BaseMarketDataProvider ──
+
+    def get_research(self, query: str, research_effort: str = "standard") -> str:
+        """
+        Perform deep research using You.com Research API.
+
+        Args:
+            query: Research topic or question
+            research_effort: lite, standard, deep, or exhaustive
+
+        Returns:
+            Markdown-formatted research report with citations
+        """
+        return youcom_news.research_news(query, research_effort)

--- a/tradingagents/dataflows/youcom_news.py
+++ b/tradingagents/dataflows/youcom_news.py
@@ -1,0 +1,141 @@
+"""You.com Search and Research API integration."""
+
+import requests
+
+from tradingagents.dataflows.config import get_config
+
+
+YOUCOM_SEARCH_URL = "https://ydc-index.io/v1/search"
+YOUCOM_RESEARCH_URL = "https://ydc-index.io/v1/research"
+
+
+def _get_api_key() -> str:
+    return get_config().get("youcom_api_key", "").strip()
+
+
+def _post(url: str, payload: dict, timeout: int = 30) -> requests.Response:
+    api_key = _get_api_key()
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    if api_key:
+        headers["X-API-Key"] = api_key
+    return requests.post(url, headers=headers, json=payload, timeout=timeout)
+
+
+def search_news(query: str, count: int = 10) -> str:
+    """
+    Search news using You.com Search API.
+
+    Args:
+        query: Search query string
+        count: Number of results (1-20)
+
+    Returns:
+        Formatted string of search results or error message
+    """
+    if not query or not query.strip():
+        return "Search query cannot be empty"
+
+    if not _get_api_key():
+        return "You.com Search API requires YOUCOM_API_KEY environment variable"
+
+    try:
+        response = _post(
+            YOUCOM_SEARCH_URL,
+            {"query": query, "count": min(max(count, 1), 20)},
+            timeout=30,
+        )
+    except Exception as e:
+        return f"You.com Search request failed: {e}"
+
+    if response.status_code == 429:
+        return "You.com Search rate limit exceeded (429)"
+    if response.status_code == 401:
+        return "You.com API Key is invalid or expired"
+    if response.status_code == 403:
+        return "You.com API Key has insufficient permissions"
+    if response.status_code != 200:
+        return f"You.com Search request failed (Status {response.status_code})"
+
+    try:
+        data = response.json()
+    except Exception:
+        return "You.com Search returned non-JSON response"
+
+    results = data.get("results", [])
+    if not results:
+        return f"No results found for: {query}"
+
+    lines = []
+    for i, item in enumerate(results[:count], 1):
+        title = item.get("title", f"Result {i}")
+        url = item.get("url", "")
+        snippets = item.get("snippets", [])
+        snippet = snippets[0] if isinstance(snippets, list) and snippets else item.get("description", "")
+        lines.append(f"[{i}] {title}\n   URL: {url}\n   Summary: {snippet}")
+
+    return "\n\n".join(lines)
+
+
+def research_news(query: str, research_effort: str = "standard") -> str:
+    """
+    Perform deep research using You.com Research API.
+
+    Args:
+        query: Research topic or question
+        research_effort: One of lite, standard, deep, exhaustive (default: standard)
+
+    Returns:
+        Markdown-formatted research report with citations or error message
+    """
+    if not query or not query.strip():
+        return "Research query cannot be empty"
+
+    if not _get_api_key():
+        return "You.com Research API requires YOUCOM_API_KEY environment variable"
+
+    allowed = {"lite", "standard", "deep", "exhaustive"}
+    if research_effort not in allowed:
+        research_effort = "standard"
+
+    try:
+        response = _post(
+            YOUCOM_RESEARCH_URL,
+            {"input": query, "research_effort": research_effort},
+            timeout=120,
+        )
+    except Exception as e:
+        return f"You.com Research request failed: {e}"
+
+    if response.status_code == 429:
+        return "You.com Research rate limit exceeded (429)"
+    if response.status_code == 401:
+        return "You.com API Key is invalid or expired"
+    if response.status_code == 403:
+        return "You.com API Key has insufficient permissions"
+    if response.status_code != 200:
+        return f"You.com Research request failed (Status {response.status_code})"
+
+    try:
+        data = response.json()
+    except Exception:
+        return "You.com Research returned non-JSON response"
+
+    content = data.get("content", "")
+    sources = data.get("sources", [])
+
+    lines = []
+    if content:
+        lines.append(f"## Research Summary\n\n{content}")
+    if sources:
+        lines.append("\n## References\n")
+        for i, source in enumerate(sources, 1):
+            snippets = source.get("snippets", [])
+            snippet = snippets[0] if isinstance(snippets, list) and snippets else ""
+            title = source.get("title", "Unknown source")
+            url = source.get("url", "")
+            lines.append(f"[{i}] {title}\n   URL: {url}\n   Summary: {snippet}")
+
+    return "\n".join(lines) if lines else "No research results returned"

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -39,7 +39,7 @@ DEFAULT_CONFIG = {
         "core_stock_apis": "cn_akshare,cn_baostock,cn_investoday,yfinance",
         "technical_indicators": "cn_akshare,cn_baostock,cn_investoday,yfinance",
         "fundamental_data": "cn_akshare,cn_baostock,cn_investoday,yfinance",
-        "news_data": "cn_akshare,cn_baostock,cn_investoday,yfinance",
+        "news_data": "cn_akshare,cn_baostock,cn_investoday,yfinance,youcom",
         "realtime_data": "cn_akshare,cn_investoday",
     },
     "tool_vendors": {},


### PR DESCRIPTION
为 A 股智能投研平台添加 You.com 联网搜索与深度研究能力，作为数据提供商接入现有 fallback chain。

### 改动内容

新增文件（3）：

- tradingagents/dataflows/youcom_news.py — Search API（search_news）和 Research API（research_news）封装函数，通过 get_config() 读取 YOUCOM_API_KEY
- tradingagents/dataflows/providers/youcom_provider.py — YoucomProvider 实现 BaseMarketDataProvider 接口：
  - get_news() — 调用 You.com Search API 搜索个股新闻
  - get_global_news() — 调用 You.com Search API 搜索全球宏观经济新闻
  - get_research() — 调用 You.com Research API 生成带引用的 Markdown 研究报告（lite/standard/deep/exhaustive 四种深度）
- tradingagents/agents/utils/youcom_news_tools.py — LangChain @tool 装饰的 get_deep_research() 工具，供分析师 Agent 直接调用进行深度研究

修改文件（5）：

- tradingagents/dataflows/providers/base.py — 在 ABC 中新增 get_research() 方法（默认抛 NotImplementedError，已有 Provider 不受影响）
- tradingagents/dataflows/providers/registry.py — 注册 YoucomProvider
- tradingagents/agents/utils/agent_utils.py — 导入 get_deep_research
- tradingagents/default_config.py — 将 youcom 加入 news_data 供应商 fallback 链
- .env.example — 新增 YOUCOM_API_KEY 环境变量说明（申请地址：https://ydc-index.io/docs）

### 架构说明

Search 路径： 现有 get_news / get_global_news 工具 → route_to_vendor() → YoucomProvider.get_news() / get_global_news() → You.com Search API，作为 cn_akshare,cn_baostock,cn_investoday,yfinance,youcom fallback 链的最后一项兜底

Research 路径： 新增 get_deep_research LangChain @tool → YoucomProvider.get_research() → You.com Research API，分析师 Agent 可直接调用进行深度研究，支持 lite/standard/deep/exhaustive 四种研究深度，返回 Markdown 综述和引用来源

### 影响范围

- 仅新增 Provider 和工具，不改变现有任何 Provider 的行为
- get_deep_research 为可选工具，不影响现有分析流程
- 需要配置 YOUCOM_API_KEY 环境变量才能启用（申请地址：https://ydc-index.io/docs）