### PR TITLE
fix(backtest): POST /v1/backtest 必定 TypeError —— _set() 的 job_id 被重复传入

### DIFF
--- a/api/services/backtest_service.py
+++ b/api/services/backtest_service.py
@@ -24,7 +24,7 @@ def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _set(job_id: str, **kwargs: Any) -> None:
+def _set(job_id: str, /, **kwargs: Any) -> None:
     with _lock:
         if job_id not in _backtest_jobs:
             _backtest_jobs[job_id] = {}


### PR DESCRIPTION
## 问题

`POST /v1/backtest` 目前**必定** 500，回测功能完全不可用。

`api/services/backtest_service.py` 里 `_set()` 的第一个形参就叫 `job_id`：

```python
def _set(job_id: str, **kwargs: Any) -> None:
    with _lock:
        if job_id not in _backtest_jobs:
            _backtest_jobs[job_id] = {}
        _backtest_jobs[job_id].update(kwargs)
```

而 `submit()` 在建任务时既按位置传了 `job_id`，又用关键字再传了一次 —— 因为初始任务记录里需要保留 `job_id` 字段供 `list_jobs()` / 前端使用：

```python
job_id = uuid4().hex
_set(job_id,
     job_id=job_id,        # <-- 与上面的位置实参撞名
     symbol=symbol,
     ...)
```

于是每次调用都抛：

```
TypeError: _set() got multiple values for argument 'job_id'
```

异常发生在 `threading.Thread(...)` 之前，所以任务连创建都创建不了，直接 500 返回给 `submit_backtest`（`api/main.py:3563`）。

另外 4 处 `_set()` 调用（`_run_backtest` 里的 `status="running"` / `total_dates=` / `completed_dates=` / `status="completed"`）都不传 `job_id=` 关键字，所以只有 `submit()` 这一处中招。

## 修法

把 `_set()` 的 `job_id` 改成 positional-only：

```python
def _set(job_id: str, /, **kwargs: Any) -> None:
```

这样 `job_id=job_id` 关键字实参会落进 `**kwargs`，**照旧被写进任务记录**（`list_jobs()` / `GET /v1/backtest/{job_id}` 的返回体里 `job_id` 字段保持不变），同时不再和位置实参冲突。改动 +1/-1，其余 4 个调用点行为完全不变。

项目 `requires-python = ">=3.10"`，PEP 570 的 `/` 语法（3.8+）可用。

## 验证

直接加载仓库里这个模块（顶层只 import 标准库），把 `threading.Thread` 替换成空实现以免真的跑起回测线程，然后调用 `submit()`：

```
--- UNPATCHED (upstream main) ---
  submit() raised: TypeError _set() got multiple values for argument 'job_id'
--- PATCHED (job_id positional-only) ---
  submit() ok, job_id = b974a4874e63499bb0d019084a0d4666
  list_jobs() -> 1 job(s); keys: ['completed_dates', 'created_at', 'end_date', 'error',
      'hold_days', 'job_id', 'records', 'sample_interval', 'selected_analysts',
      'start_date', 'stats', 'status', 'symbol', 'total_dates']
  job['job_id'] present: True == returned id: True
  status: pending | created_at set: True
--- other _set call sites, patched ---
  ok -> {'status': 'completed', 'total_dates': 3, 'completed_dates': 1,
         'records': [], 'error': None, 'finished_at': 't', 'stats': None}
```

`job_id` 字段仍在，其余四个内部调用点也依旧正常。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
