### PR TITLE
fix: deepseek 端点优先级与 _log_state* UTF-8 写盘（附回归）

### DIFF
--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -609,7 +609,7 @@ class TestPortfolioOverviewEndpoint:
             )
             db.commit()
 
-        with patch("api.main._get_reverse_stock_map", return_value=self.code_to_name):
+        with patch("api.main._get_reverse_stock_map_cached_only", return_value=self.code_to_name):
             response = self.client.get("/v1/portfolio/overview", headers=self.headers)
 
         assert response.status_code == 200
@@ -693,7 +693,7 @@ class TestScheduledBatchEndpoints:
             coro.close()
             return MagicMock()
 
-        with patch("api.main._run_scheduled_analysis_once", run_once), \
+        with patch("api.main._run_manual_trigger", run_once), \
              patch("api.main._create_tracked_task", side_effect=_close_coro), \
              patch("api.main.cn_today_str", return_value="2026-03-31"), \
              patch("api.main._resolve_scheduled_trade_date", return_value="2026-03-31"):
@@ -713,7 +713,7 @@ class TestScheduledBatchEndpoints:
         assert args[0]["user_id"]
         assert args[1] == "2026-03-31"
         assert args[2] == body["job_id"]
-        assert kwargs == {"mark_schedule_run": False}
+        assert kwargs == {}   # 当前架构 _run_manual_trigger(task, requested_date, job_id)，无 mark_schedule_run
 
     def test_batch_trigger_endpoint_queues_selected_tasks_with_position_context(self):
         from api.database import ImportedPortfolioPositionDB, get_db_ctx
@@ -743,7 +743,7 @@ class TestScheduledBatchEndpoints:
             coro.close()
             return MagicMock()
 
-        with patch("api.main._run_scheduled_analysis_once", run_once), \
+        with patch("api.main._run_manual_trigger", run_once), \
              patch("api.main._create_tracked_task", side_effect=_close_coro), \
              patch("api.main.cn_today_str", return_value="2026-03-31"), \
              patch("api.main._resolve_scheduled_trade_date", return_value="2026-03-31"), \
@@ -775,5 +775,5 @@ class TestScheduledBatchEndpoints:
         assert second_args[0]["symbol"] == "600519.SH"
         assert first_args[1] == "2026-03-31"
         assert second_args[1] == "2026-03-31"
-        assert first_kwargs == {"mark_schedule_run": False}
-        assert second_kwargs == {"mark_schedule_run": False}
+        assert first_kwargs == {}
+        assert second_kwargs == {}

--- a/tests/test_deepseek_patch_regression.py
+++ b/tests/test_deepseek_patch_regression.py
@@ -1,0 +1,124 @@
+"""回归：本地补丁 2026-09-06（deepseek 端点优先级 + _log_state* UTF-8 写盘）。
+
+不发起任何网络/LLM 调用，可离线执行。
+"""
+
+import json
+
+from tradingagents.graph.trading_graph import TradingAgentsGraph
+from tradingagents.llm_clients.factory import create_llm_client
+
+
+def _llm_base(client) -> str:
+    return client.get_llm().openai_api_base
+
+
+def test_deepseek_ignores_openai_default_base_url(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    for bad in (
+        "https://api.openai.com/v1",
+        "https://api.openai.com/v1/",
+        "https://api.openai.com",
+    ):
+        llm = _llm_base(
+            create_llm_client(provider="deepseek", model="deepseek-chat", base_url=bad)
+        )
+        assert llm == "https://api.deepseek.com"
+
+
+def test_deepseek_default_base_url_is_deepseek(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    llm = _llm_base(create_llm_client(provider="deepseek", model="deepseek-chat"))
+    assert llm == "https://api.deepseek.com"
+
+
+def test_deepseek_honors_explicit_custom_gateway(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    llm = _llm_base(
+        create_llm_client(
+            provider="deepseek", model="deepseek-chat",
+            base_url="https://gw.example.com/v1",
+        )
+    )
+    assert llm == "https://gw.example.com/v1"
+
+
+def test_graph_with_openai_default_backend_url_resolves_deepseek(monkeypatch):
+    """复现 v3 触发条件：config.backend_url 仍是默认 api.openai.com/v1，
+    provider=deepseek -> 两端 LLM 都必须解析到 DeepSeek 端点。"""
+    from tradingagents.default_config import DEFAULT_CONFIG
+
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = DEFAULT_CONFIG.copy()
+    config["llm_provider"] = "deepseek"
+    config["deep_think_llm"] = "deepseek-reasoner"
+    config["quick_think_llm"] = "deepseek-chat"
+    config["backend_url"] = "https://api.openai.com/v1"  # fork 默认值（含 bug 场景）
+    config["api_key"] = ""
+    ta = TradingAgentsGraph(debug=False, config=config)
+    assert ta.deep_thinking_llm.openai_api_base == "https://api.deepseek.com"
+    assert ta.quick_thinking_llm.openai_api_base == "https://api.deepseek.com"
+
+
+def _nested_state_skeleton() -> dict:
+    """覆盖 _log_state 读取的全部键。"""
+    debate = {
+        "bull_history": [], "bear_history": [], "history": [],
+        "current_speaker": "", "current_response": "", "judge_decision": "",
+        "claims": [], "focus_claim_ids": [], "open_claim_ids": [],
+        "resolved_claim_ids": [], "unresolved_claim_ids": [],
+        "round_summary": "", "round_goal": "",
+    }
+    risk = {
+        "aggressive_history": [], "conservative_history": [], "neutral_history": [],
+        "history": [], "judge_decision": "", "claims": [],
+        "focus_claim_ids": [], "open_claim_ids": [], "resolved_claim_ids": [],
+        "unresolved_claim_ids": [], "round_summary": "", "round_goal": "",
+    }
+    return {
+        "company_of_interest": "688469",
+        "trade_date": "2026-09-04",
+        "market_report": "❌ 数据缺口（emoji 回归）",
+        "sentiment_report": "⚠️ 中性",
+        "news_report": "news",
+        "fundamentals_report": "fund",
+        "macro_report": "macro",
+        "smart_money_report": "smart",
+        "volume_price_report": "vol",
+        "investment_plan": "plan",
+        "trader_investment_plan": "trader",
+        "final_trade_decision": "SELL ✅",
+        "investment_debate_state": debate,
+        "risk_debate_state": risk,
+        "risk_feedback_state": {},
+    }
+
+
+def test_log_state_writes_utf8_with_emoji(tmp_path, monkeypatch):
+    ta = TradingAgentsGraph.__new__(TradingAgentsGraph)
+    ta.ticker = "688469"
+    ta.log_states_dict = {}
+    monkeypatch.chdir(tmp_path)
+    ta._log_state("2026-09-04", _nested_state_skeleton())
+    fp = tmp_path / "eval_results/688469/TradingAgentsStrategy_logs/full_states_log_2026-09-04.json"
+    assert fp.exists()
+    raw = fp.read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    # _log_state 用 ensure_ascii=True，emoji 以 \uXXXX 转义存储；解码后必须还原
+    assert "❌" in parsed["2026-09-04"]["market_report"]
+    assert "✅" in parsed["2026-09-04"]["final_trade_decision"]
+
+
+def test_log_state_dual_writes_utf8_with_emoji(tmp_path, monkeypatch):
+    ta = TradingAgentsGraph.__new__(TradingAgentsGraph)
+    ta.ticker = "688469"
+    ta.log_states_dict = {}
+    monkeypatch.chdir(tmp_path)
+    short = {"company_of_interest": "688469", "final_trade_decision": "SELL ✅"}
+    ta._log_state_dual("2026-09-04", short, {}, {"raw_query": ""})
+    fp = tmp_path / "eval_results/688469/TradingAgentsStrategy_logs/dual_horizon_2026-09-04.json"
+    assert fp.exists()
+    raw = fp.read_text(encoding="utf-8")
+    assert "✅" in raw
+    assert json.loads(raw)

--- a/tradingagents/graph/trading_graph.py
+++ b/tradingagents/graph/trading_graph.py
@@ -396,6 +396,7 @@ class TradingAgentsGraph:
         with open(
             f"eval_results/{ticker}/TradingAgentsStrategy_logs/dual_horizon_{trade_date}.json",
             "w",
+            encoding="utf-8",   # 本地补丁(2026-09-06)：默认 GBK 写 emoji 会崩
         ) as f:
             json.dump(entry, f, indent=4, ensure_ascii=False)
 
@@ -462,6 +463,7 @@ class TradingAgentsGraph:
         with open(
             f"eval_results/{safe_ticker}/TradingAgentsStrategy_logs/full_states_log_{trade_date}.json",
             "w",
+            encoding="utf-8",   # 本地补丁(2026-09-06)：默认 GBK 写 emoji 会崩
         ) as f:
             json.dump(self.log_states_dict, f, indent=4)
 

--- a/tradingagents/llm_clients/openai_client.py
+++ b/tradingagents/llm_clients/openai_client.py
@@ -113,7 +113,16 @@ class OpenAIClient(BaseLLMClient):
             llm_kwargs["base_url"] = "http://localhost:11434/v1"
             llm_kwargs["api_key"] = "ollama"
         elif self.provider == "deepseek":
-            llm_kwargs["base_url"] = self.base_url or "https://api.deepseek.com"
+            # 本地补丁(2026-09-06)：端点优先级修复。default_config 的 backend_url
+            # 默认值是 api.openai.com/v1，若被当作 base_url 采纳会覆盖 DeepSeek 端点
+            # 导致 401。仅当显式传入非 OpenAI 默认端点(如自定义 deepseek 兼容网关)时才采用。
+            if self.base_url and self.base_url.rstrip("/").lower() not in (
+                "https://api.openai.com",
+                "https://api.openai.com/v1",
+            ):
+                llm_kwargs["base_url"] = self.base_url
+            else:
+                llm_kwargs["base_url"] = "https://api.deepseek.com"
             api_key = os.environ.get("DEEPSEEK_API_KEY")
             if api_key: llm_kwargs["api_key"] = api_key
         elif self.base_url:


### PR DESCRIPTION
## fix: deepseek 端点优先级 + _log_state* UTF-8 写盘

### 问题
1. `provider=deepseek` 且未显式设置 `TA_BASE_URL` 时，`default_config.backend_url`
   默认为 `https://api.openai.com/v1`，被 `OpenAIClient` 当作 base_url 采纳，
   覆盖 DeepSeek 端点 -> 全部 LLM 调用 401（DeepSeek key 对 OpenAI 无效）。
2. `_log_state_dual` / `_log_state` 用系统默认编码写文件；Windows 简体中文环境
   为 GBK，模型报告含 emoji（❌/⚠）时抛 `UnicodeEncodeError`，图结果随进程丢失。

### 修复
- `OpenAIClient` deepseek 分支：仅采纳**非 OpenAI 默认端点**的显式 base_url
  （保留自定义 deepseek 兼容网关/代理能力），否则固定 `https://api.deepseek.com`。
- `_log_state*` 两处文件写入点补 `encoding="utf-8"`。

### 测试
- 新增离线回归 `tests/test_deepseek_patch_regression.py`：
  - OpenAI 默认端点被忽略 ×3（含尾斜杠与无 /v1 变体）
  - 自定义 deepseek 兼容网关仍被采纳
  - 图构造（保持默认 backend_url）两端 LLM 解析到 DeepSeek 端点
  - `_log_state` / `_log_state_dual` 写盘含 emoji 且 JSON 可回读
- 修正 `tests/test_api_smoke.py` 中随架构漂移的 patch 指向
  （`_run_scheduled_analysis_once` → `_run_manual_trigger`；
   `_get_reverse_stock_map` → `_get_reverse_stock_map_cached_only`）。
- 验证：新增回归 + 关联套件通过；`api.main` / `scheduler.main` 导入通过；
  复现原 401 场景（`backend_url` 保持默认 + 进程内无 `OPENAI_API_KEY`）后
  真实 DeepSeek 调用返回 OK；`tests/test_api_smoke.py` 36 passed。

### 兼容性
- 显式把 `TA_BASE_URL` 指向自定义 OpenAI 兼容网关的 deepseek 用法不受影响。
- 对未打补丁的旧行为无破坏：仅当 base_url 为 OpenAI 默认端点时才不再采纳。